### PR TITLE
ci: enforce conventional commit style

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,0 +1,29 @@
+name: "Check PR Title"
+on:
+  pull_request:
+    types:
+      [
+        opened,
+        synchronize,
+        reopened,
+        ready_for_review,
+        labeled,
+        unlabeled,
+        converted_to_draft,
+        edited,
+      ]
+
+permissions:
+  pull-requests: read # to read PR title and labels
+
+jobs:
+  check-pr-title:
+    name: Check PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce conventional commit style
+        uses: realm/ci-actions/title-checker@d6cc8f067474759d38e6d24e272027b4c88bc0a9
+        with:
+          regex: '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|ops){1}(\([\w\-\.]+\))?(!)?: .*'
+          error-hint: 'Invalid PR title. Make sure it follows the conventional commit specification (i.e. "<type>(<optional scope>): <description>") or add the no-title-validation label'
+          ignore-labels: "no-title-validation"


### PR DESCRIPTION
Enforce conventional commit style.

Copied from: https://github.com/mongodb-js/mongodb-mcp-server/blob/47c0a09e0be765b3c51cf2bf224565e136374a38/.github/workflows/check-pr-title.yml

Jira ticket: [\[MCP-171\] \[atlas-local-rs\] enforce conventional commit style](https://jira.mongodb.org/browse/MCP-171)