### PR TITLE
feat: Add e2e job to CI that runs Docker-in-Docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,9 +62,6 @@ jobs:
     - name: Build
       run: cargo build --verbose
     
-    - name: Run tests
-      run: cargo test --verbose
-    
     - name: Run cargo deny
       run: cargo deny check
     
@@ -73,6 +70,7 @@ jobs:
 
   test-matrix:
     runs-on: ${{ matrix.os }}
+
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
@@ -85,7 +83,7 @@ jobs:
             rust: beta
     steps:
     - uses: actions/checkout@v4
-    
+
     - name: Install Rust toolchain
       run: |
         rustup update ${{ matrix.rust }}
@@ -106,7 +104,7 @@ jobs:
       run: cargo build --verbose
     
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose --lib -- --skip "e2e_test"
 
   # Minimum supported Rust version check
   msrv:
@@ -132,3 +130,27 @@ jobs:
     
     - name: Check MSRV build
       run: cargo check --verbose
+
+  e2e-tests:
+      runs-on: ubuntu-latest
+      services:
+        docker:
+          image: docker:dind
+          options: --privileged
+          ports:
+            - 2375:2375
+      container:
+        image: ubuntu:latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+
+        - name: Install dependencies
+          run: |
+            apt-get update
+            apt-get install -y curl gcc
+        - name: Install Rust toolchain
+          uses: actions-rust-lang/setup-rust-toolchain@v1
+            
+        - name: Run E2E Tests
+          run: cargo test --verbose --tests


### PR DESCRIPTION
# Description
Jira ticket: [MCP-167](https://jira.mongodb.org/browse/MCP-167)

## Main change
- Separates e2e jobs from the rest of the test matrix because these tests need a docker daemon to connect to
- Only runs on Ubuntu the e2e test spins up a minimal alpine container, which does not work on windows and the Mac runner does not have docker installed

Example run (on fork)
https://github.com/Luke-Sanderson/atlas-local-lib/actions/runs/17497859515/job/49703192523?pr=6
