### PR TITLE
feat: Add wait_until_healthy option to CreateDeploymentOptions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     
-    - name: Install Rust 1.89 (edition 2024 requirement)
+    - name: Install Rust 1.89
       run: |
         rustup update 1.89
         rustup default 1.89

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,10 +112,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     
-    - name: Install Rust 1.85 (edition 2024 requirement)
+    - name: Install Rust 1.89 (edition 2024 requirement)
       run: |
-        rustup update 1.85
-        rustup default 1.85
+        rustup update 1.89
+        rustup default 1.89
     
     - name: Cache cargo registry
       uses: actions/cache@v4
@@ -124,9 +124,9 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
           target
-        key: ${{ runner.os }}-1.85-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-1.89-cargo-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
-          ${{ runner.os }}-1.85-cargo-
+          ${{ runner.os }}-1.89-cargo-
     
     - name: Check MSRV build
       run: cargo check --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ mockall = "0.13.1"
 rand = "0.9.2"
 semver = "1.0.26"
 thiserror = "2.0.16"
+tokio = { version = "1.0", features = ["time"] }
 
 [dev-dependencies]
 anyhow = "1.0.99"

--- a/examples/delete_deployments.rs
+++ b/examples/delete_deployments.rs
@@ -13,6 +13,7 @@ async fn main() -> Result<()> {
         .context("Deleting atlas local container local1234")?;
     println!("local1234 successfully deleted");
 
+    // This should fail as the container is not a local Atlas container
     client
         .delete_deployment("other_none_local_atlas")
         .await

--- a/src/client/create_deployment.rs
+++ b/src/client/create_deployment.rs
@@ -23,8 +23,6 @@ pub enum CreateDeploymentError {
     PullImage(#[from] PullImageError),
     #[error("Container already exists: {0}")]
     ContainerAlreadyExists(String),
-    #[error("Architecture not supported by Atlas Local: {0}")]
-    UnsupportedArchitecture(String),
     #[error("Failed to check status of started container: {0}")]
     ContainerInspect(bollard::errors::Error),
     #[error("Created Deployment {0} is not healthy")]
@@ -183,7 +181,7 @@ mod tests {
     async fn test_create_deployment() {
         // Arrange
         let mut mock_docker = MockDocker::new();
-        let create_options = CreateDeploymentOptions {
+        let options = CreateDeploymentOptions {
             name: Some("test-deployment".to_string()),
             ..Default::default()
         };
@@ -240,7 +238,7 @@ mod tests {
         let client = Client::new(mock_docker);
 
         // Act
-        let result = client.create_deployment(&create_options).await;
+        let result = client.create_deployment(&options).await;
 
         // Assert
         assert!(result.is_ok());

--- a/src/client/create_deployment.rs
+++ b/src/client/create_deployment.rs
@@ -1,3 +1,4 @@
+#![feature(result_flattening)]
 use bollard::{
     errors::Error::DockerResponseServerError,
     query_parameters::{CreateContainerOptions, InspectContainerOptions, StartContainerOptions},

--- a/src/client/create_deployment.rs
+++ b/src/client/create_deployment.rs
@@ -1,4 +1,3 @@
-#![feature(result_flattening)]
 use bollard::{
     errors::Error::DockerResponseServerError,
     query_parameters::{CreateContainerOptions, InspectContainerOptions, StartContainerOptions},

--- a/src/models/create_deployment_options.rs
+++ b/src/models/create_deployment_options.rs
@@ -1,5 +1,3 @@
-use std::vec;
-
 use bollard::{
     query_parameters::CreateContainerOptions,
     secret::{ContainerCreateBody, HostConfig, PortBinding},
@@ -7,6 +5,7 @@ use bollard::{
 use maplit::hashmap;
 use rand::Rng;
 use semver::Version;
+use std::{time::Duration, vec};
 
 use crate::models::{
     CreationSource, ENV_VAR_DO_NOT_TRACK, ENV_VAR_MONGODB_INITDB_DATABASE,
@@ -30,6 +29,7 @@ pub struct CreateDeploymentOptions {
 
     // Creation Options
     pub wait_until_healthy: Option<bool>,
+    pub wait_until_healthy_timeout: Option<Duration>,
     pub creation_source: Option<CreationSource>,
 
     // Initial database configuration
@@ -208,6 +208,7 @@ mod tests {
             image: Some(ATLAS_LOCAL_IMAGE.to_string()),
             mongodb_version: Some(ATLAS_LOCAL_VERSION_TAG),
             wait_until_healthy: Some(true),
+            wait_until_healthy_timeout: Some(Duration::from_secs(60)),
             creation_source: Some(CreationSource::Container),
             local_seed_location: Some("/host/seed-data".to_string()),
             mongodb_initdb_database: Some("testdb".to_string()),
@@ -369,6 +370,7 @@ mod tests {
         assert!(options.image.is_none());
         assert!(options.mongodb_version.is_none());
         assert!(options.wait_until_healthy.is_none());
+        assert!(options.wait_until_healthy_timeout.is_none());
         assert!(options.creation_source.is_none());
         assert!(options.local_seed_location.is_none());
         assert!(options.mongodb_initdb_database.is_none());

--- a/src/models/create_deployment_options.rs
+++ b/src/models/create_deployment_options.rs
@@ -28,7 +28,8 @@ pub struct CreateDeploymentOptions {
     pub image: Option<String>,
     pub mongodb_version: Option<Version>,
 
-    // Creation source
+    // Creation Options
+    pub wait_until_healthy: Option<bool>,
     pub creation_source: Option<CreationSource>,
 
     // Initial database configuration
@@ -206,6 +207,7 @@ mod tests {
             name: Some("deployment_name".to_string()),
             image: Some(ATLAS_LOCAL_IMAGE.to_string()),
             mongodb_version: Some(ATLAS_LOCAL_VERSION_TAG),
+            wait_until_healthy: Some(true),
             creation_source: Some(CreationSource::Container),
             local_seed_location: Some("/host/seed-data".to_string()),
             mongodb_initdb_database: Some("testdb".to_string()),
@@ -237,6 +239,14 @@ mod tests {
             Some(&LOCAL_DEPLOYMENT_LABEL_VALUE.to_string())
         );
 
+        // Check Creation Options
+        assert_eq!(create_deployment_options.wait_until_healthy, Some(true));
+        assert_eq!(
+            create_deployment_options.creation_source,
+            Some(CreationSource::Container)
+        );
+
+        // Check environment variables
         let env_vars = container_create_body.env.unwrap();
         assert!(env_vars.contains(&format!("{}=CONTAINER", ENV_VAR_TOOL)));
         assert!(env_vars.contains(&format!("{}=/tmp/runner.log", ENV_VAR_RUNNER_LOG_FILE)));
@@ -358,6 +368,7 @@ mod tests {
         assert!(options.name.is_none());
         assert!(options.image.is_none());
         assert!(options.mongodb_version.is_none());
+        assert!(options.wait_until_healthy.is_none());
         assert!(options.creation_source.is_none());
         assert!(options.local_seed_location.is_none());
         assert!(options.mongodb_initdb_database.is_none());


### PR DESCRIPTION
# Description
Jira ticket: [MCP-192](https://jira.mongodb.org/browse/MCP-192)

## Main change
- Added `wait_until_healthy` option to `CreateDeploymentOptions`
- Added new related errors
- Added timeout 
  - Copies timeout [value from AtlasCLI](https://github.com/mongodb/mongodb-atlas-cli/blob/1b644656a681c401243d13fd4439c2ca18b15fd3/internal/cli/deployments/setup.go#L260-L261)
- Active by default so will become active in upstream e2e tests without additional changes

## Flyby
- Add clarification comment to delete example