### PR TITLE
feat!: git add emoved verify option and switch to quay.io

### DIFF
--- a/examples/get_connection_string.rs
+++ b/examples/get_connection_string.rs
@@ -21,7 +21,6 @@ async fn main() -> Result<()> {
             container_id_or_name: deployment.container_id,
             db_username: Some(username),
             db_password: Some(password),
-            verify: Some(true),
         };
         let conn_str = client
             .get_connection_string(req)

--- a/src/client/get_deployment_id.rs
+++ b/src/client/get_deployment_id.rs
@@ -22,7 +22,6 @@ impl<D: DockerInspectContainer> Client<D> {
             container_id_or_name: cluster_id_or_name.to_string(),
             db_username: None,
             db_password: None,
-            verify: Some(false),
         };
         let connection_string = self
             .get_connection_string(get_connection_string_options)
@@ -61,7 +60,6 @@ mod tests {
 
         #[async_trait::async_trait]
         impl MongoDbClient for MongoClientFactory {
-            async fn list_database_names(&self, connection_string: &str) -> Result<Vec<String>, mongodb::error::Error>;
             async fn get_deployment_id(&self, connection_string: &str) -> Result<String, GetDeploymentIdError>;
         }
     }

--- a/src/models/create_deployment_options.rs
+++ b/src/models/create_deployment_options.rs
@@ -15,7 +15,7 @@ use crate::models::{
     LOCAL_DEPLOYMENT_LABEL_KEY, LOCAL_DEPLOYMENT_LABEL_VALUE,
 };
 use crate::models::{MongoDBPortBinding, deployment::LOCAL_SEED_LOCATION};
-pub const ATLAS_LOCAL_IMAGE: &str = "mongodb/mongodb-atlas-local";
+pub const ATLAS_LOCAL_IMAGE: &str = "quay.io/mongodb/mongodb-atlas-local";
 pub const ATLAS_LOCAL_VERSION_TAG: Version = Version::new(8, 0, 0);
 
 #[derive(Debug, Default)]
@@ -230,7 +230,7 @@ mod tests {
         // Assert all fields are set correctly
         assert_eq!(
             container_create_body.image,
-            Some("mongodb/mongodb-atlas-local:8.0.0".to_string())
+            Some("quay.io/mongodb/mongodb-atlas-local:8.0.0".to_string())
         );
         assert_eq!(
             container_create_body

--- a/src/models/get_connection_string_options.rs
+++ b/src/models/get_connection_string_options.rs
@@ -3,5 +3,4 @@ pub struct GetConnectionStringOptions {
     pub container_id_or_name: String,
     pub db_username: Option<String>,
     pub db_password: Option<String>,
-    pub verify: Option<bool>,
 }

--- a/src/mongodb.rs
+++ b/src/mongodb.rs
@@ -1,10 +1,9 @@
 use crate::client::GetDeploymentIdError;
 use async_trait::async_trait;
-use mongodb::{Client, bson::Document, error::Error};
+use mongodb::{Client, bson::Document};
 
 #[async_trait]
 pub trait MongoDbClient {
-    async fn list_database_names(&self, connection_string: &str) -> Result<Vec<String>, Error>;
     async fn get_deployment_id(
         &self,
         connection_string: &str,
@@ -15,12 +14,6 @@ pub struct MongoDbAdapter;
 
 #[async_trait]
 impl MongoDbClient for MongoDbAdapter {
-    async fn list_database_names(&self, connection_string: &str) -> Result<Vec<String>, Error> {
-        let client_options = mongodb::options::ClientOptions::parse(connection_string).await?;
-        let mongo_client = Client::with_options(client_options)?;
-        mongo_client.list_database_names().await
-    }
-
     async fn get_deployment_id(
         &self,
         connection_string: &str,

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -94,7 +94,6 @@ async fn test_e2e_smoke_test() {
         container_id_or_name: name.to_string(),
         db_username: Some(username.to_string()),
         db_password: Some(password.to_string()),
-        verify: Some(false),
     };
 
     let conn_string = client


### PR DESCRIPTION
Remove `verify` from `get_connection_string` options.

Just because we can connect from the place where `atlas-local` runs does not mean the receiver of the connection string will be able to establish a connection. The other way around is also true.

Flyby:
- switch to `quay.io` to pull our `atlas-local` image, `quay.io` doesn't require authentication, Docker Hub does.

Jira: [\[MCP-225\] \[atlas-local-rs\] Remove verify from GetConnectionStringOptions](https://jira.mongodb.org/browse/MCP-225)