### PR TITLE
chore: makes MongoDbClient  trait thread-safe

### DIFF
--- a/src/mongodb.rs
+++ b/src/mongodb.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use mongodb::{Client, bson::Document};
 
 #[async_trait]
-pub trait MongoDbClient {
+pub trait MongoDbClient: Send + Sync {
     async fn get_deployment_id(
         &self,
         connection_string: &str,


### PR DESCRIPTION
Adds supertraits `Send` and `Sync` to trait `MongoDbClient`

#### Reasoning 
Using latest commits (commits since the introduction of MongoDbClient) in JS lib caused napi(and tokio) to complain `future cannot be sent between threads safely`