### PR TITLE
chore: dissalow use of unwrap/expect/panic in codebase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       run: cargo fmt --all -- --check
     
     - name: Run clippy
-      run: cargo clippy --all-targets --all-features -- -D warnings
+      run: cargo clippy -- -D warnings
     
     - name: Build
       run: cargo build --verbose

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
 #![doc = include_str!("../README.md")]
+#![deny(clippy::unwrap_used)]
+#![deny(clippy::expect_used)]
+#![deny(clippy::panic)]
 
 pub mod client;
 pub mod docker;

--- a/src/models/create_deployment_options.rs
+++ b/src/models/create_deployment_options.rs
@@ -144,14 +144,8 @@ impl From<&CreateDeploymentOptions> for ContainerCreateBody {
         })
         .collect::<Vec<String>>();
 
-        match deployment_options.creation_source {
-            Some(CreationSource::AtlasCLI) => env_vars.push(format!("{}=ATLASCLI", ENV_VAR_TOOL)),
-            Some(CreationSource::Container) => env_vars.push(format!("{}=CONTAINER", ENV_VAR_TOOL)),
-            Some(CreationSource::MCPServer) => env_vars.push(format!("{}=MCPSERVER", ENV_VAR_TOOL)),
-            Some(CreationSource::Unknown(ref s)) => {
-                env_vars.push(format!("{}={}", ENV_VAR_TOOL, s))
-            }
-            None => {}
+        if let Some(source) = deployment_options.creation_source.as_ref() {
+            env_vars.push(format!("{ENV_VAR_TOOL}={source}"));
         }
 
         // Only set env if we have any to set, otherwise leave it as None

--- a/src/models/creation_source.rs
+++ b/src/models/creation_source.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum CreationSource {
     AtlasCLI,
@@ -13,6 +15,17 @@ impl From<&str> for CreationSource {
             "CONTAINER" => CreationSource::Container,
             "MCPSERVER" => CreationSource::MCPServer,
             unknown => CreationSource::Unknown(unknown.to_string()),
+        }
+    }
+}
+
+impl Display for CreationSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CreationSource::AtlasCLI => write!(f, "ATLASCLI"),
+            CreationSource::Container => write!(f, "CONTAINER"),
+            CreationSource::MCPServer => write!(f, "MCPSERVER"),
+            CreationSource::Unknown(s) => write!(f, "{}", s),
         }
     }
 }
@@ -46,5 +59,29 @@ mod tests {
             source,
             CreationSource::Unknown("some_unknown_source".to_string())
         );
+    }
+
+    #[test]
+    fn test_creation_source_to_string_atlascli() {
+        let source = CreationSource::AtlasCLI;
+        assert_eq!(source.to_string(), "ATLASCLI");
+    }
+
+    #[test]
+    fn test_creation_source_to_string_container() {
+        let source = CreationSource::Container;
+        assert_eq!(source.to_string(), "CONTAINER");
+    }
+
+    #[test]
+    fn test_creation_source_to_string_mcp_server() {
+        let source = CreationSource::MCPServer;
+        assert_eq!(source.to_string(), "MCPSERVER");
+    }
+
+    #[test]
+    fn test_creation_source_to_string_unknown() {
+        let source = CreationSource::Unknown("custom_source".to_string());
+        assert_eq!(source.to_string(), "custom_source");
     }
 }

--- a/src/models/port_binding.rs
+++ b/src/models/port_binding.rs
@@ -46,6 +46,7 @@ impl MongoDBPortBinding {
         }
 
         // It's safe to unwrap because we checked the length above
+        #[allow(clippy::unwrap_used)]
         let port = ports.first().unwrap();
 
         // Get the port number (convert optional string to u16)


### PR DESCRIPTION
# Changes
- CI: don't run clippy on tests
- Disallow the use of `unwarp`/`expecte`/`panic` in code
- Removed/annotated existing uses of `unwrap` in codebase

Flyby:
- Implemented `Display` for creation source and used it in `CreateDeploymentOptions`
- Improved test coverage in updated areas