### PR TITLE
Mcp 216

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ env:
   CARGO_DENY_VERSION: 0.18.4
   CARGO_AUDIT_VERSION: 0.21.2
   CARGO_LLVM_COV_VERSION: 0.6.19
+  CARGO_UDEPS_VERSION: 0.1.59
 
 jobs:
   check:
@@ -22,6 +23,7 @@ jobs:
         rustup update stable
         rustup default stable
         rustup component add clippy rustfmt
+        rustup toolchain install nightly
     
     - name: Cache cargo registry
       uses: actions/cache@v4
@@ -38,7 +40,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/.cargo/bin
-        key: ${{ runner.os }}-cargo-tools-deny-${{ env.CARGO_DENY_VERSION }}-audit-${{ env.CARGO_AUDIT_VERSION }}
+        key: ${{ runner.os }}-cargo-tools-deny-${{ env.CARGO_DENY_VERSION }}-audit-${{ env.CARGO_AUDIT_VERSION }}-udeps-${{ env.CARGO_UDEPS_VERSION }}
         restore-keys: |
           ${{ runner.os }}-cargo-tools-
     
@@ -52,6 +54,12 @@ jobs:
       run: |
         if ! command -v cargo-audit &> /dev/null; then
           cargo install --locked --version ${{ env.CARGO_AUDIT_VERSION }} cargo-audit
+        fi
+    
+    - name: Install cargo-udeps
+      run: |
+        if ! command -v cargo-udeps &> /dev/null; then
+          cargo install --locked --version ${{ env.CARGO_UDEPS_VERSION }} cargo-udeps
         fi
     
     - name: Check formatting
@@ -68,6 +76,12 @@ jobs:
     
     - name: Run cargo audit
       run: cargo audit
+    
+    - name: Run cargo udeps (package dependencies)
+      run: cargo +nightly udeps
+
+    - name: Run cargo udeps (dev dependencies)
+      run: cargo +nightly udeps --all-features --all-targets
 
   test-matrix:
     runs-on: ${{ matrix.os }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,19 +10,16 @@ include = [
     "README.md",
     "CONTRIBUTING.md",
     "LICENSE",
-    "license.html"
+    "license.html",
 ]
 
 [features]
 e2e-tests = []
 
 [dependencies]
-async-trait = "0.1.89"
 bollard = "0.19.2"
 futures-util = "0.3.31"
 maplit = "1.0.2"
-mockall = "0.13.1"
-mongodb = "3.3.0"
 rand = "0.9.2"
 semver = "1.0.26"
 thiserror = "2.0.16"
@@ -30,5 +27,6 @@ tokio = { version = "1.0", features = ["time"] }
 
 [dev-dependencies]
 anyhow = "1.0.99"
+mockall = "0.13.1"
 pretty_assertions = "1.4.1"
 tokio = { version = "1.0", features = ["full"] }

--- a/deny.toml
+++ b/deny.toml
@@ -38,7 +38,7 @@ targets = [
 # they are connected to another crate in the graph that hasn't been pruned,
 # so it should be used with care. The identifiers are [Package ID Specifications]
 # (https://doc.rust-lang.org/cargo/reference/pkgid-spec.html)
-exclude = ["mongodb"]
+exclude = []
 # If true, metadata will be collected with `--all-features`. Note that this can't
 # be toggled off if true, if you want to conditionally enable `--all-features` it
 # is recommended to pass `--all-features` on the cmd line instead

--- a/src/client/get_connection_string.rs
+++ b/src/client/get_connection_string.rs
@@ -13,8 +13,6 @@ pub enum GetConnectionStringError {
     GetDeployment(#[from] GetDeploymentError),
     #[error("Missing port binding information")]
     MissingPortBinding,
-    #[error("Failed to connect to MongoDB: {0}")]
-    MongoConnect(#[from] mongodb::error::Error),
 }
 
 impl<D: DockerInspectContainer> Client<D> {


### PR DESCRIPTION
There was no need to expand the cargo deny list.
The MongoDB driver is not used anymore due to #23 

# Changes
- Removed `mongo` from the `exclude` list in `deny.toml`
- Removed leftover references to `mongo` package in the code
- Added `cargo udeps` check to scan for unused dependencies in both the package (`dependencies`) and tests/examples (`dev-dependencies`)

Jira: [\[MCP-216\] \[atlas-local-rs\] Investigate expanding the cargo deny allow list](https://jira.mongodb.org/browse/MCP-216)