### PR TITLE
ci: added dependabot for cargo and github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,32 +8,20 @@ updates:
       day: "monday"
       time: "09:00"
     open-pull-requests-limit: 10
-    reviewers:
-      - "mongodb/apix-2"
-    assignees:
-      - "mongodb/apix-2"
     commit-message:
-      prefix: "chore"
-      include: "scope"
+      prefix: "chore(deps)"
     labels:
       - "dependencies"
-      - "rust"
-    # Auto-merge patch and minor updates after CI passes
-    auto-merge:
-      - dependency-type: "all"
-        update-type: "security"
-      - dependency-type: "all"
-        update-type: "patch"
-      - dependency-type: "all"
-        update-type: "minor"
-    # Group minor and patch updates together to reduce PR noise
+    # Group updates by type to separate security from version updates
     groups:
-      rust-minor-patch:
+      rust-security:
+        applies-to: security-updates
         patterns:
           - "*"
-        update-types:
-          - "minor"
-          - "patch"
+      rust-version-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
@@ -43,21 +31,7 @@ updates:
       day: "monday"
       time: "09:00"
     open-pull-requests-limit: 5
-    reviewers:
-      - "mongodb/apix-2"
-    assignees:
-      - "mongodb/apix-2"
     commit-message:
-      prefix: "chore"
-      include: "scope"
+      prefix: "chore(deps)"
     labels:
       - "dependencies"
-      - "github-actions"
-    # Auto-merge patch and minor updates after CI passes
-    auto-merge:
-      - dependency-type: "all"
-        update-type: "security"
-      - dependency-type: "all"
-        update-type: "patch"
-      - dependency-type: "all"
-        update-type: "minor"

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -1,0 +1,33 @@
+name: Dependabot Auto-Approve
+
+on: pull_request
+
+permissions:
+  pull-requests: write
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    if: |
+      github.repository == 'mongodb/atlas-local-lib' &&
+      github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      
+      - name: Approve Dependabot PR
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' || contains(steps.metadata.outputs.dependency-names, 'security')
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Enable auto-merge for Dependabot PR
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' || contains(steps.metadata.outputs.dependency-names, 'security')
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Jira: [\[MCP-256\] \[atlas-local-rs\] Set up dependabot for repository](https://jira.mongodb.org/browse/MCP-256)