### PR TITLE
feat: add voyage api key and move preview to mod_version enum

### DIFF
--- a/src/client/create_deployment/progress.rs
+++ b/src/client/create_deployment/progress.rs
@@ -211,6 +211,7 @@ mod tests {
             mongodb_initdb_root_username_file: None,
             mongodb_initdb_root_username: None,
             mongodb_load_sample_data: None,
+            voyage_api_key: None,
             mongot_log_file: None,
             runner_log_file: None,
             do_not_track: false,

--- a/src/client/get_deployment.rs
+++ b/src/client/get_deployment.rs
@@ -120,6 +120,7 @@ mod tests {
                 mongodb_initdb_root_username_file: None,
                 mongodb_initdb_root_username: None,
                 mongodb_load_sample_data: None,
+                voyage_api_key: None,
                 mongot_log_file: None,
                 runner_log_file: None,
                 do_not_track: false,

--- a/src/models/create_deployment_options.rs
+++ b/src/models/create_deployment_options.rs
@@ -11,7 +11,7 @@ use crate::models::{
     ENV_VAR_MONGODB_INITDB_ROOT_PASSWORD, ENV_VAR_MONGODB_INITDB_ROOT_PASSWORD_FILE,
     ENV_VAR_MONGODB_INITDB_ROOT_USERNAME, ENV_VAR_MONGODB_INITDB_ROOT_USERNAME_FILE,
     ENV_VAR_MONGODB_LOAD_SAMPLE_DATA, ENV_VAR_MONGOT_LOG_FILE, ENV_VAR_RUNNER_LOG_FILE,
-    ENV_VAR_TELEMETRY_BASE_URL, ENV_VAR_TOOL, LOCAL_DEPLOYMENT_LABEL_KEY,
+    ENV_VAR_TELEMETRY_BASE_URL, ENV_VAR_TOOL, ENV_VAR_VOYAGE_API_KEY, LOCAL_DEPLOYMENT_LABEL_KEY,
     LOCAL_DEPLOYMENT_LABEL_VALUE, MongoDBVersion,
 };
 use crate::models::{MongoDBPortBinding, deployment::LOCAL_SEED_LOCATION};
@@ -60,6 +60,7 @@ pub struct CreateDeploymentOptions {
     pub mongodb_initdb_root_password: Option<String>,
     pub mongodb_initdb_root_username_file: Option<String>,
     pub mongodb_initdb_root_username: Option<String>,
+    pub voyage_api_key: Option<String>,
     pub load_sample_data: Option<bool>,
 
     // Logging
@@ -152,6 +153,10 @@ impl From<&CreateDeploymentOptions> for ContainerCreateBody {
                     .as_ref(),
             ),
             (
+                ENV_VAR_VOYAGE_API_KEY,
+                deployment_options.voyage_api_key.as_ref(),
+            ),
+            (
                 ENV_VAR_MONGOT_LOG_FILE,
                 deployment_options.mongot_log_file.as_ref(),
             ),
@@ -242,6 +247,7 @@ mod tests {
             mongodb_initdb_root_password: Some("password123".to_string()),
             mongodb_initdb_root_username_file: Some("/run/secrets/username".to_string()),
             mongodb_initdb_root_username: Some("admin".to_string()),
+            voyage_api_key: Some("voyage-api-key".to_string()),
             load_sample_data: Some(true),
             mongot_log_file: Some("/tmp/mongot.log".to_string()),
             runner_log_file: Some("/tmp/runner.log".to_string()),
@@ -299,7 +305,8 @@ mod tests {
             "{}=https://telemetry.example.com",
             ENV_VAR_TELEMETRY_BASE_URL
         )));
-        assert_eq!(env_vars.len(), 11);
+        assert!(env_vars.contains(&format!("{}=voyage-api-key", ENV_VAR_VOYAGE_API_KEY)));
+        assert_eq!(env_vars.len(), 12);
 
         let host_config = container_create_body.host_config.unwrap();
         let port_bindings = host_config.port_bindings.unwrap();
@@ -407,6 +414,7 @@ mod tests {
         assert!(options.mongodb_initdb_root_password.is_none());
         assert!(options.mongodb_initdb_root_username_file.is_none());
         assert!(options.mongodb_initdb_root_username.is_none());
+        assert!(options.voyage_api_key.is_none());
         assert!(options.load_sample_data.is_none());
         assert!(options.mongot_log_file.is_none());
         assert!(options.runner_log_file.is_none());

--- a/src/models/deployment.rs
+++ b/src/models/deployment.rs
@@ -35,6 +35,7 @@ pub struct Deployment {
     pub mongodb_initdb_root_username_file: Option<String>,
     pub mongodb_initdb_root_username: Option<String>,
     pub mongodb_load_sample_data: Option<bool>,
+    pub voyage_api_key: Option<String>,
 
     // Logging
     pub mongot_log_file: Option<String>,
@@ -101,6 +102,7 @@ impl TryFrom<ContainerInspectResponse> for Deployment {
             mongot_log_file,
             do_not_track,
             telemetry_base_url,
+            voyage_api_key,
         } = container_environment_variables;
 
         Ok(Self {
@@ -127,6 +129,7 @@ impl TryFrom<ContainerInspectResponse> for Deployment {
             mongodb_initdb_root_username_file,
             mongodb_initdb_root_username,
             mongodb_load_sample_data: mongodb_load_sample_data.map(is_seeding_true),
+            voyage_api_key,
 
             // Logging
             mongot_log_file,
@@ -199,6 +202,7 @@ mod tests {
             "MONGOT_LOG_FILE=/tmp/mongot.log".to_string(),
             "TELEMETRY_BASE_URL=https://telemetry.example.com".to_string(),
             "MONGODB_LOAD_SAMPLE_DATA=true".to_string(),
+            "VOYAGE_API_KEY=voyage-api-key".to_string(),
         ];
 
         // Create a mount for local seed location
@@ -294,6 +298,10 @@ mod tests {
             Some("https://telemetry.example.com".to_string())
         );
         assert_eq!(deployment.mongodb_load_sample_data, Some(true));
+        assert_eq!(
+            deployment.voyage_api_key,
+            Some("voyage-api-key".to_string())
+        );
     }
 
     #[test]

--- a/src/models/environment_variables.rs
+++ b/src/models/environment_variables.rs
@@ -15,6 +15,7 @@ pub const ENV_VAR_MONGOT_LOG_FILE: &str = "MONGOT_LOG_FILE";
 pub const ENV_VAR_DO_NOT_TRACK: &str = "DO_NOT_TRACK";
 pub const ENV_VAR_TELEMETRY_BASE_URL: &str = "TELEMETRY_BASE_URL";
 pub const ENV_VAR_MONGODB_LOAD_SAMPLE_DATA: &str = "MONGODB_LOAD_SAMPLE_DATA";
+pub const ENV_VAR_VOYAGE_API_KEY: &str = "VOYAGE_API_KEY";
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -38,6 +39,8 @@ pub struct EnvironmentVariables {
     pub telemetry_base_url: Option<String>,
 
     pub mongodb_load_sample_data: Option<String>,
+
+    pub voyage_api_key: Option<String>,
 }
 
 impl From<&ContainerInspectResponse> for EnvironmentVariables {
@@ -77,6 +80,7 @@ impl From<&ContainerInspectResponse> for EnvironmentVariables {
         environment_variables.telemetry_base_url = get_value(&env, ENV_VAR_TELEMETRY_BASE_URL);
         environment_variables.mongodb_load_sample_data =
             get_value(&env, ENV_VAR_MONGODB_LOAD_SAMPLE_DATA);
+        environment_variables.voyage_api_key = get_value(&env, ENV_VAR_VOYAGE_API_KEY);
 
         environment_variables
     }
@@ -169,6 +173,7 @@ mod tests {
                 ENV_VAR_TELEMETRY_BASE_URL
             ),
             format!("{}=true", ENV_VAR_MONGODB_LOAD_SAMPLE_DATA),
+            format!("{}=voyage-api-key", ENV_VAR_VOYAGE_API_KEY),
         ];
 
         let container_response = ContainerInspectResponse {
@@ -214,6 +219,7 @@ mod tests {
             Some("https://telemetry.example.com".to_string())
         );
         assert_eq!(env_vars.mongodb_load_sample_data, Some("true".to_string()));
+        assert_eq!(env_vars.voyage_api_key, Some("voyage-api-key".to_string()));
     }
 
     #[test]

--- a/src/models/mdb_version.rs
+++ b/src/models/mdb_version.rs
@@ -4,6 +4,7 @@ use std::fmt::{Display, Formatter};
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MongoDBVersion {
     Latest,
+    Preview,
     Major(MongoDBVersionMajor),
     MajorMinor(MongoDBVersionMajorMinor),
     MajorMinorPatch(MongoDBVersionMajorMinorPatch),
@@ -46,6 +47,11 @@ impl TryFrom<&str> for MongoDBVersion {
             return Ok(MongoDBVersion::Latest);
         }
 
+        // Special case for preview version.
+        if s == "preview" {
+            return Ok(MongoDBVersion::Preview);
+        }
+
         // Split the version string by '.' and parse each part as a u8.
         // If that fails, return the PARSE_ERROR_MESSAGE.
         let parts = s
@@ -78,6 +84,7 @@ impl Display for MongoDBVersion {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             MongoDBVersion::Latest => write!(f, "latest"),
+            MongoDBVersion::Preview => write!(f, "preview"),
             MongoDBVersion::Major(major) => write!(f, "{}", major.major),
             MongoDBVersion::MajorMinor(major_minor) => {
                 write!(f, "{}.{}", major_minor.major, major_minor.minor)
@@ -100,6 +107,13 @@ mod tests {
         let version = MongoDBVersion::try_from("latest").unwrap();
         assert_eq!(version, MongoDBVersion::Latest);
         assert_eq!(version.to_string(), "latest");
+    }
+
+    #[test]
+    fn test_parse_preview() {
+        let version = MongoDBVersion::try_from("preview").unwrap();
+        assert_eq!(version, MongoDBVersion::Preview);
+        assert_eq!(version.to_string(), "preview");
     }
 
     #[test]


### PR DESCRIPTION
Jira [\[CLOUDP-377858\] \[Atlas Local CLI\] Support setup with preview tag](https://jira.mongodb.org/browse/CLOUDP-377858)

- Adds new voyage_api_key option to the deployment model
- Changes preview from being an option to being a Enum value of mdbVersion in line with how latest is passed