### PR TITLE
ci: improve release workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -3,20 +3,13 @@ name: Prepare Release
 on:
   workflow_dispatch:
     inputs:
-      bump:
-        description: 'Version bump type'
+      version:
+        description: 'Exact version (e.g., 1.0.0) or one of: major, minor, patch'
         required: true
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
-      exact_version:
-        description: 'Exact version override (e.g., 1.0.0). Leave empty to use bump type.'
-        required: false
+        default: 'patch'
         type: string
 
-run-name: "Prepare release: ${{ inputs.exact_version || inputs.bump }}"
+run-name: "Prepare release: ${{ inputs.version }}"
 
 permissions:
   contents: read
@@ -50,14 +43,16 @@ jobs:
       - name: Update Cargo.toml version
         id: set-version
         env:
-          EXACT_VERSION: ${{ github.event.inputs.exact_version }}
-          BUMP: ${{ github.event.inputs.bump }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          if [ -n "$EXACT_VERSION" ]; then
-            cargo set-version "$EXACT_VERSION"
-          else
-            cargo set-version --bump "$BUMP"
-          fi
+          case "$INPUT_VERSION" in
+            major|minor|patch)
+              cargo set-version --bump "$INPUT_VERSION"
+              ;;
+            *)
+              cargo set-version "$INPUT_VERSION"
+              ;;
+          esac
           VERSION=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[0].version')
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
       - name: Update third-party licenses

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -19,6 +19,16 @@ jobs:
     name: Update Version
     runs-on: ubuntu-latest
     steps:
+      - name: Validate version input
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          if [[ "$INPUT_VERSION" =~ ^(major|minor|patch)$ ]] || [[ "$INPUT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "Valid version input: $INPUT_VERSION"
+          else
+            echo "::error::Invalid version input '$INPUT_VERSION'. Must be 'major', 'minor', 'patch', or a semver version (e.g., 1.2.3)."
+            exit 1
+          fi
       - name: Set Apix Bot token
         id: app-token
         uses: mongodb/apix-action/token@6c3fde402c21942fa46cde003f190c2b23c59530

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,85 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      exact_version:
+        description: 'Exact version override (e.g., 1.0.0). Leave empty to use bump type.'
+        required: false
+        type: string
+
+run-name: "Prepare release: ${{ inputs.exact_version || inputs.bump }}"
+
+permissions:
+  contents: read
+
+jobs:
+  update-version:
+    name: Update Version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set Apix Bot token
+        id: app-token
+        uses: mongodb/apix-action/token@6c3fde402c21942fa46cde003f190c2b23c59530
+        with:
+          app-id: ${{ secrets.APIXBOT_APP_ID }}
+          private-key: ${{ secrets.APIXBOT_APP_PEM }}
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: x86_64-unknown-linux-gnu
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@v1.17.6
+      - name: Install cargo-edit to update Cargo.toml version
+        run: cargo binstall --no-confirm --locked cargo-edit
+      - name: Install cargo tools for license verification
+        run: cargo binstall --no-confirm --locked cargo-about
+      - name: Update Cargo.toml version
+        id: set-version
+        env:
+          EXACT_VERSION: ${{ github.event.inputs.exact_version }}
+          BUMP: ${{ github.event.inputs.bump }}
+        run: |
+          if [ -n "$EXACT_VERSION" ]; then
+            cargo set-version "$EXACT_VERSION"
+          else
+            cargo set-version --bump "$BUMP"
+          fi
+          VERSION=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[0].version')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Update third-party licenses
+        run: cargo about generate about.hbs > LICENSE-3RD-PARTY.txt
+      - name: Generate changelog
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --tag ${{ steps.set-version.outputs.version }} --verbose
+        env:
+          OUTPUT: CHANGELOG.md
+          GITHUB_REPO: ${{ github.repository }}
+      - name: Commit version changes
+        env:
+          GIT_USER_NAME: ${{ steps.app-token.outputs.user-name }}
+          GIT_USER_EMAIL: ${{ steps.app-token.outputs.user-email }}
+          VERSION: ${{ steps.set-version.outputs.version }}
+        run: |
+          git config --global user.name "$GIT_USER_NAME"
+          git config --global user.email "$GIT_USER_EMAIL"
+          git add Cargo.toml Cargo.lock CHANGELOG.md LICENSE-3RD-PARTY.txt
+          git commit -m "chore(release): prepare for $VERSION"
+          git tag "v$VERSION"
+          git push
+          git push --tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,152 +1,53 @@
+# Runs when a version tag (e.g. v1.0.0) is pushed. Creates the GitHub release and
+# publishes to Crates.io. Re-run this workflow if publish fails without re-doing
+# the prepare-release commits.
 name: Release
 
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version to release (e.g., 1.0.0)'
-        required: true
-        type: string
-
-run-name: "Release: ${{ inputs.version }}"
+  push:
+    tags:
+      - 'v[0-9]*'
 
 permissions:
-  contents: read
-  id-token: write # Required for trusted publishing
+  contents: write
+  id-token: write
 
 jobs:
-  update-version-and-changelog:
-    # This job:
-    # - updates the version in Cargo.toml
-    # - generates a changelog (also generates a release notes file)
-    # - commits the changes to the repository with the message "chore(release): prepare for ${{ github.event.inputs.version }}"
-    name: Update Version and Changelog
+  create-github-release:
+    name: Create GitHub Release
     runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-      tag: ${{ steps.tag.outputs.tag }}
     steps:
-      - name: Set Apix Bot token
-        id: app-token
-        uses: mongodb/apix-action/token@6c3fde402c21942fa46cde003f190c2b23c59530
-        with:
-          app-id: ${{ secrets.APIXBOT_APP_ID }}
-          private-key: ${{ secrets.APIXBOT_APP_PEM }}
       - uses: actions/checkout@v6
         with:
-          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-          targets: x86_64-unknown-linux-gnu
-      - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@v1.17.6
-      - name: Install cargo-edit to update Cargo.toml version
-        run: cargo binstall --no-confirm --locked cargo-edit
-      - name: Install cargo tools for license verification
-        run: cargo binstall --no-confirm --locked cargo-about
-      - name: Update Cargo.toml version
-        env:
-            VERSION: ${{ github.event.inputs.version }}
-        run: cargo set-version "$VERSION"
-      - name: Update third-party licenses
-        run: cargo about generate about.hbs > LICENSE-3RD-PARTY.txt
-      - name: Generate changelog
-        uses: orhun/git-cliff-action@v4
-        with:
-          config: cliff.toml
-          args: --tag ${{ github.event.inputs.version }} --verbose
-        env:
-          OUTPUT: CHANGELOG.md
-          GITHUB_REPO: ${{ github.repository }}
       - name: Generate release notes
         uses: orhun/git-cliff-action@v4
         with:
           config: cliff.toml
-          args: --tag ${{ github.event.inputs.version }} --verbose --unreleased
+          args: --tag ${{ github.ref_name }} --verbose --latest
         env:
           OUTPUT: RELEASE_NOTES.md
           GITHUB_REPO: ${{ github.repository }}
-      - name: Upload release notes artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: release-notes
-          path: RELEASE_NOTES.md
-          if-no-files-found: error
-      - name: Commit version changes
-        env:
-            GIT_USER_NAME: ${{ steps.app-token.outputs.user-name }}
-            GIT_USER_EMAIL: ${{ steps.app-token.outputs.user-email }}
-            VERSION: ${{ github.event.inputs.version }}
-        run: |
-            git config --global user.name "$GIT_USER_NAME"
-            git config --global user.email "$GIT_USER_EMAIL"
-            git add Cargo.toml Cargo.lock CHANGELOG.md LICENSE-3RD-PARTY.txt
-            git commit -m "chore(release): prepare for $VERSION"
-            git push
-      - name: Create and push tag
-        env:
-            VERSION: ${{ github.event.inputs.version }}
-        run: |
-            git tag "v$VERSION"
-            git push origin "v$VERSION"
-      - name: Set version output
-        id: version
-        env:
-            VERSION: ${{ github.event.inputs.version }}
-        run: echo "version=$VERSION" >> $GITHUB_OUTPUT
-      - name: Set tag output
-        id: tag
-        env:
-            VERSION: ${{ github.event.inputs.version }}
-        run: echo "tag=v$VERSION" >> $GITHUB_OUTPUT
-
-  create-github-release:
-    # This job creates a GitHub release for the given version, using the release notes file generated in the previous job.
-    name: Create GitHub Release
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    needs: [update-version-and-changelog]
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ needs.update-version-and-changelog.outputs.tag }}
-      - name: Download all artifacts
-        uses: actions/download-artifact@v8
-        with:
-          path: artifacts
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ needs.update-version-and-changelog.outputs.tag }}
-          name: Release ${{ needs.update-version-and-changelog.outputs.tag }}
-          body_path: artifacts/release-notes/RELEASE_NOTES.md
-          files: |
-            # Include only the source code in the release (no binaries).
-            # This will create a release with the tarball/zip assets auto-attached by GitHub,
-            # containing the full repository source (checked out at the release commit).
-            #
-            # No additional files specified here means only the GitHub auto-generated archives are included.
-            # Remove the below lines to avoid uploading build artifacts.
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          body_path: RELEASE_NOTES.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    
+
   publish-to-crates-io:
-    # This job publishes the crate to Crates.io using trusted publishing.
     name: Publish to Crates.io
     runs-on: ubuntu-latest
     permissions:
-        id-token: write
-    needs: [update-version-and-changelog]
+      id-token: write
     steps:
-    - uses: actions/checkout@v6
-      with:
-        ref: ${{ needs.update-version-and-changelog.outputs.tag }}
-    - uses: rust-lang/crates-io-auth-action@v1
-      id: auth
-    - run: cargo publish
-      env:
-        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+      - run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
- Splits into prepare-release.yml and release.yml to allow safe re-runs on publish failure
- Make the input a major, minor, patch dropdown to avoid typos (with override)