### PR TITLE
ci: use apix-bot instead of github actions to update dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -16,10 +16,17 @@ jobs:
       github.repository == 'mongodb/atlas-local-lib' &&
       github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
+      - name: Set Apix Bot token
+        id: app-token
+        uses: mongodb/apix-action/token@6c3fde402c21942fa46cde003f190c2b23c59530
+        with:
+          app-id: ${{ secrets.APIXBOT_APP_ID }}
+          private-key: ${{ secrets.APIXBOT_APP_PEM }}
+
       - name: Checkout PR
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
@@ -56,8 +63,8 @@ jobs:
           
           # Check if there are changes to commit
           if ! git diff --quiet LICENSE-3RD-PARTY.txt; then
-            git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git config --local user.name "github-actions[bot]"
+            git config --local user.email "${{ steps.app-token.outputs.user-email }}"
+            git config --local user.name "${{ steps.app-token.outputs.user-name }}"
             git add LICENSE-3RD-PARTY.txt
             git commit -m "chore(deps): update LICENSE-3RD-PARTY.txt"
             git push
@@ -71,11 +78,11 @@ jobs:
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
       
       - name: Enable auto-merge for Dependabot PR
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' || contains(steps.metadata.outputs.dependency-names, 'security') || steps.metadata.outputs.package-ecosystem == 'github_actions'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,9 +867,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom",

--- a/LICENSE-3RD-PARTY.txt
+++ b/LICENSE-3RD-PARTY.txt
@@ -3427,7 +3427,7 @@ limitations under the License.
         - proc-macro2 1.0.101 (https://github.com/dtolnay/proc-macro2)
         - quote 1.0.40 (https://github.com/dtolnay/quote)
         - r-efi 5.3.0 (https://github.com/r-efi/r-efi)
-        - rand 0.10.0 (https://github.com/rust-random/rand)
+        - rand 0.10.1 (https://github.com/rust-random/rand)
         - rustversion 1.0.22 (https://github.com/dtolnay/rustversion)
         - ryu 1.0.20 (https://github.com/dtolnay/ryu)
         - semver 1.0.27 (https://github.com/dtolnay/semver)


### PR DESCRIPTION
Jira: [CLOUDP-397175](https://jira.mongodb.org/browse/CLOUDP-397175)

Some PRs are not triggering github action checks (example https://github.com/mongodb/atlas-local-lib/pull/95)