### PR TITLE
Fix bollard 0.20.2 compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,9 +71,9 @@ checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
 
 [[package]]
 name = "bollard"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227aa051deec8d16bd9c34605e7aaf153f240e35483dd42f6f78903847934738"
+checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
 dependencies = [
  "base64",
  "bollard-stubs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ e2e-tests = []
 serde = ["dep:serde", "semver/serde"]
 
 [dependencies]
-bollard = "0.20.1"
+bollard = "0.20"
 bytes = "1.11"
 chrono = "0.4.44"
 futures = "0.3.32"

--- a/LICENSE-3RD-PARTY.txt
+++ b/LICENSE-3RD-PARTY.txt
@@ -448,7 +448,7 @@ OVERVIEW OF LICENSES:
 -----------------------------------------------------------------------------
                         Apache License 2.0
         applies to: 
-        - bollard 0.20.1 (https://github.com/fussybeaver/bollard)
+        - bollard 0.20.2 (https://github.com/fussybeaver/bollard)
         - hyper-named-pipe 0.1.0 (https://github.com/fussybeaver/hyper-named-pipe)
 -----------------------------------------------------------------------------
 

--- a/src/client/create_deployment/mod.rs
+++ b/src/client/create_deployment/mod.rs
@@ -1,7 +1,7 @@
 use bollard::{
     errors::Error::DockerResponseServerError,
-    query_parameters::{CreateContainerOptions, StartContainerOptions},
     models::ContainerCreateBody,
+    query_parameters::{CreateContainerOptions, StartContainerOptions},
 };
 use tokio::sync::oneshot;
 
@@ -190,11 +190,11 @@ mod tests {
     use crate::models::ImageTag;
     use bollard::{
         errors::Error as BollardError,
-        query_parameters::InspectContainerOptions,
         models::{
             ContainerConfig, ContainerCreateResponse, ContainerInspectResponse, ContainerState,
             ContainerStateStatusEnum, HealthStatusEnum,
         },
+        query_parameters::InspectContainerOptions,
     };
     use maplit::hashmap;
     use mockall::mock;

--- a/src/client/create_deployment/mod.rs
+++ b/src/client/create_deployment/mod.rs
@@ -1,7 +1,7 @@
 use bollard::{
     errors::Error::DockerResponseServerError,
     query_parameters::{CreateContainerOptions, StartContainerOptions},
-    secret::ContainerCreateBody,
+    models::ContainerCreateBody,
 };
 use tokio::sync::oneshot;
 
@@ -191,7 +191,7 @@ mod tests {
     use bollard::{
         errors::Error as BollardError,
         query_parameters::InspectContainerOptions,
-        secret::{
+        models::{
             ContainerConfig, ContainerCreateResponse, ContainerInspectResponse, ContainerState,
             ContainerStateStatusEnum, HealthStatusEnum,
         },
@@ -248,7 +248,7 @@ mod tests {
             }),
             state: Some(ContainerState {
                 status: Some(ContainerStateStatusEnum::RUNNING),
-                health: Some(bollard::secret::Health {
+                health: Some(bollard::models::Health {
                     status: Some(HealthStatusEnum::HEALTHY),
                     ..Default::default()
                 }),
@@ -272,7 +272,7 @@ mod tests {
                 ..Default::default()
             }),
             state: Some(ContainerState {
-                health: Some(bollard::secret::Health {
+                health: Some(bollard::models::Health {
                     status: Some(HealthStatusEnum::UNHEALTHY),
                     ..Default::default()
                 }),
@@ -296,7 +296,7 @@ mod tests {
                 ..Default::default()
             }),
             state: Some(ContainerState {
-                health: Some(bollard::secret::Health {
+                health: Some(bollard::models::Health {
                     status: Some(HealthStatusEnum::STARTING),
                     ..Default::default()
                 }),
@@ -359,7 +359,7 @@ mod tests {
                 ..Default::default()
             }),
             state: Some(ContainerState {
-                health: Some(bollard::secret::Health {
+                health: Some(bollard::models::Health {
                     status: None,
                     ..Default::default()
                 }),

--- a/src/client/delete_deployment.rs
+++ b/src/client/delete_deployment.rs
@@ -46,7 +46,7 @@ mod tests {
     use super::*;
     use bollard::{
         errors::Error as BollardError, query_parameters::InspectContainerOptions,
-        secret::ContainerInspectResponse,
+        models::ContainerInspectResponse,
     };
     use mockall::mock;
 
@@ -79,7 +79,7 @@ mod tests {
     }
 
     fn create_test_container_inspect_response() -> ContainerInspectResponse {
-        use bollard::secret::{ContainerConfig, ContainerState, ContainerStateStatusEnum};
+        use bollard::models::{ContainerConfig, ContainerState, ContainerStateStatusEnum};
         use std::collections::HashMap;
 
         let mut labels = HashMap::new();

--- a/src/client/delete_deployment.rs
+++ b/src/client/delete_deployment.rs
@@ -45,8 +45,8 @@ impl<D: DockerStopContainer + DockerRemoveContainer + DockerInspectContainer> Cl
 mod tests {
     use super::*;
     use bollard::{
-        errors::Error as BollardError, query_parameters::InspectContainerOptions,
-        models::ContainerInspectResponse,
+        errors::Error as BollardError, models::ContainerInspectResponse,
+        query_parameters::InspectContainerOptions,
     };
     use mockall::mock;
 

--- a/src/client/get_connection_string.rs
+++ b/src/client/get_connection_string.rs
@@ -3,7 +3,7 @@ use crate::{
     docker::{DockerInspectContainer, RunCommandInContainer, RunCommandInContainerError},
     models::MongoDBPortBinding,
 };
-use bollard::secret::PortBinding;
+use bollard::models::PortBinding;
 
 use super::GetDeploymentError;
 
@@ -107,7 +107,7 @@ mod tests {
     use bollard::{
         errors::Error as BollardError,
         query_parameters::InspectContainerOptions,
-        secret::{
+        models::{
             ContainerConfig, ContainerInspectResponse, ContainerState, ContainerStateStatusEnum,
         },
     };
@@ -246,7 +246,7 @@ mod tests {
                 status: Some(ContainerStateStatusEnum::RUNNING),
                 ..Default::default()
             }),
-            network_settings: Some(bollard::secret::NetworkSettings {
+            network_settings: Some(bollard::models::NetworkSettings {
                 ports: Some(hashmap! {}), // No port mappings
                 ..Default::default()
             }),

--- a/src/client/get_connection_string.rs
+++ b/src/client/get_connection_string.rs
@@ -106,10 +106,10 @@ mod tests {
     };
     use bollard::{
         errors::Error as BollardError,
-        query_parameters::InspectContainerOptions,
         models::{
             ContainerConfig, ContainerInspectResponse, ContainerState, ContainerStateStatusEnum,
         },
+        query_parameters::InspectContainerOptions,
     };
     use maplit::hashmap;
     use mockall::mock;

--- a/src/client/get_deployment.rs
+++ b/src/client/get_deployment.rs
@@ -41,7 +41,7 @@ mod tests {
     use crate::models::{CreationSource, MongodbType, State};
     use bollard::{
         errors::Error as BollardError,
-        secret::{
+        models::{
             ContainerConfig, ContainerInspectResponse, ContainerState, ContainerStateStatusEnum,
         },
     };

--- a/src/client/get_deployment_id.rs
+++ b/src/client/get_deployment_id.rs
@@ -83,10 +83,10 @@ mod tests {
     use crate::{client::get_deployment::GetDeploymentError, docker::CommandOutput};
     use bollard::{
         errors::Error as BollardError,
-        query_parameters::InspectContainerOptions,
         models::{
             ContainerConfig, ContainerInspectResponse, ContainerState, ContainerStateStatusEnum,
         },
+        query_parameters::InspectContainerOptions,
     };
     use maplit::hashmap;
     use mockall::{mock, predicate::eq};

--- a/src/client/get_deployment_id.rs
+++ b/src/client/get_deployment_id.rs
@@ -84,7 +84,7 @@ mod tests {
     use bollard::{
         errors::Error as BollardError,
         query_parameters::InspectContainerOptions,
-        secret::{
+        models::{
             ContainerConfig, ContainerInspectResponse, ContainerState, ContainerStateStatusEnum,
         },
     };

--- a/src/client/list_deployments.rs
+++ b/src/client/list_deployments.rs
@@ -50,11 +50,11 @@ mod tests {
     use crate::models::{MongodbType, State};
     use bollard::{
         errors::Error as BollardError,
-        query_parameters::{InspectContainerOptions, ListContainersOptions},
         models::{
             ContainerConfig, ContainerInspectResponse, ContainerState, ContainerStateStatusEnum,
             ContainerSummary,
         },
+        query_parameters::{InspectContainerOptions, ListContainersOptions},
     };
     use mockall::mock;
     use std::collections::HashMap;

--- a/src/client/list_deployments.rs
+++ b/src/client/list_deployments.rs
@@ -51,7 +51,7 @@ mod tests {
     use bollard::{
         errors::Error as BollardError,
         query_parameters::{InspectContainerOptions, ListContainersOptions},
-        secret::{
+        models::{
             ContainerConfig, ContainerInspectResponse, ContainerState, ContainerStateStatusEnum,
             ContainerSummary,
         },

--- a/src/client/pause_deployment.rs
+++ b/src/client/pause_deployment.rs
@@ -36,7 +36,7 @@ mod tests {
     use super::*;
     use bollard::{
         errors::Error as BollardError, query_parameters::InspectContainerOptions,
-        secret::ContainerInspectResponse,
+        models::ContainerInspectResponse,
     };
     use mockall::mock;
 
@@ -57,7 +57,7 @@ mod tests {
     }
 
     fn create_test_container_inspect_response() -> ContainerInspectResponse {
-        use bollard::secret::{ContainerConfig, ContainerState, ContainerStateStatusEnum};
+        use bollard::models::{ContainerConfig, ContainerState, ContainerStateStatusEnum};
         use std::collections::HashMap;
 
         let mut labels = HashMap::new();

--- a/src/client/pause_deployment.rs
+++ b/src/client/pause_deployment.rs
@@ -35,8 +35,8 @@ impl<D: DockerPauseContainer + DockerInspectContainer> Client<D> {
 mod tests {
     use super::*;
     use bollard::{
-        errors::Error as BollardError, query_parameters::InspectContainerOptions,
-        models::ContainerInspectResponse,
+        errors::Error as BollardError, models::ContainerInspectResponse,
+        query_parameters::InspectContainerOptions,
     };
     use mockall::mock;
 

--- a/src/client/start_deployment.rs
+++ b/src/client/start_deployment.rs
@@ -37,8 +37,8 @@ impl<D: DockerStartContainer + DockerInspectContainer> Client<D> {
 mod tests {
     use super::*;
     use bollard::{
-        errors::Error as BollardError, query_parameters::InspectContainerOptions,
-        models::ContainerInspectResponse,
+        errors::Error as BollardError, models::ContainerInspectResponse,
+        query_parameters::InspectContainerOptions,
     };
     use mockall::mock;
 

--- a/src/client/start_deployment.rs
+++ b/src/client/start_deployment.rs
@@ -38,7 +38,7 @@ mod tests {
     use super::*;
     use bollard::{
         errors::Error as BollardError, query_parameters::InspectContainerOptions,
-        secret::ContainerInspectResponse,
+        models::ContainerInspectResponse,
     };
     use mockall::mock;
 
@@ -63,7 +63,7 @@ mod tests {
     }
 
     fn create_test_container_inspect_response() -> ContainerInspectResponse {
-        use bollard::secret::{ContainerConfig, ContainerState, ContainerStateStatusEnum};
+        use bollard::models::{ContainerConfig, ContainerState, ContainerStateStatusEnum};
         use std::collections::HashMap;
 
         let mut labels = HashMap::new();

--- a/src/client/stop_deployment.rs
+++ b/src/client/stop_deployment.rs
@@ -37,8 +37,8 @@ impl<D: DockerStopContainer + DockerInspectContainer> Client<D> {
 mod tests {
     use super::*;
     use bollard::{
-        errors::Error as BollardError, query_parameters::InspectContainerOptions,
-        models::ContainerInspectResponse,
+        errors::Error as BollardError, models::ContainerInspectResponse,
+        query_parameters::InspectContainerOptions,
     };
     use mockall::mock;
 

--- a/src/client/stop_deployment.rs
+++ b/src/client/stop_deployment.rs
@@ -38,7 +38,7 @@ mod tests {
     use super::*;
     use bollard::{
         errors::Error as BollardError, query_parameters::InspectContainerOptions,
-        secret::ContainerInspectResponse,
+        models::ContainerInspectResponse,
     };
     use mockall::mock;
 
@@ -63,7 +63,7 @@ mod tests {
     }
 
     fn create_test_container_inspect_response() -> ContainerInspectResponse {
-        use bollard::secret::{ContainerConfig, ContainerState, ContainerStateStatusEnum};
+        use bollard::models::{ContainerConfig, ContainerState, ContainerStateStatusEnum};
         use std::collections::HashMap;
 
         let mut labels = HashMap::new();

--- a/src/client/unpause_deployment.rs
+++ b/src/client/unpause_deployment.rs
@@ -36,7 +36,7 @@ mod tests {
     use super::*;
     use bollard::{
         errors::Error as BollardError, query_parameters::InspectContainerOptions,
-        secret::ContainerInspectResponse,
+        models::ContainerInspectResponse,
     };
     use mockall::mock;
 
@@ -57,7 +57,7 @@ mod tests {
     }
 
     fn create_test_container_inspect_response() -> ContainerInspectResponse {
-        use bollard::secret::{ContainerConfig, ContainerState, ContainerStateStatusEnum};
+        use bollard::models::{ContainerConfig, ContainerState, ContainerStateStatusEnum};
         use std::collections::HashMap;
 
         let mut labels = HashMap::new();

--- a/src/client/unpause_deployment.rs
+++ b/src/client/unpause_deployment.rs
@@ -35,8 +35,8 @@ impl<D: DockerUnpauseContainer + DockerInspectContainer> Client<D> {
 mod tests {
     use super::*;
     use bollard::{
-        errors::Error as BollardError, query_parameters::InspectContainerOptions,
-        models::ContainerInspectResponse,
+        errors::Error as BollardError, models::ContainerInspectResponse,
+        query_parameters::InspectContainerOptions,
     };
     use mockall::mock;
 

--- a/src/client/watch_deployment.rs
+++ b/src/client/watch_deployment.rs
@@ -1,5 +1,5 @@
-use bollard::query_parameters::InspectContainerOptions;
 use bollard::models::HealthStatusEnum;
+use bollard::query_parameters::InspectContainerOptions;
 use tokio::time;
 
 use crate::{client::Client, docker::DockerInspectContainer, models::WatchOptions};

--- a/src/client/watch_deployment.rs
+++ b/src/client/watch_deployment.rs
@@ -1,5 +1,5 @@
 use bollard::query_parameters::InspectContainerOptions;
-use bollard::secret::HealthStatusEnum;
+use bollard::models::HealthStatusEnum;
 use tokio::time;
 
 use crate::{client::Client, docker::DockerInspectContainer, models::WatchOptions};
@@ -114,7 +114,7 @@ mod tests {
     use super::*;
     use bollard::{
         errors::Error as BollardError,
-        secret::{
+        models::{
             ContainerConfig, ContainerInspectResponse, ContainerState, ContainerStateStatusEnum,
             HealthStatusEnum,
         },
@@ -150,7 +150,7 @@ mod tests {
             }),
             state: Some(ContainerState {
                 status: Some(ContainerStateStatusEnum::RUNNING),
-                health: Some(bollard::secret::Health {
+                health: Some(bollard::models::Health {
                     status: Some(HealthStatusEnum::HEALTHY),
                     ..Default::default()
                 }),
@@ -174,7 +174,7 @@ mod tests {
                 ..Default::default()
             }),
             state: Some(ContainerState {
-                health: Some(bollard::secret::Health {
+                health: Some(bollard::models::Health {
                     status: Some(HealthStatusEnum::UNHEALTHY),
                     ..Default::default()
                 }),
@@ -198,7 +198,7 @@ mod tests {
                 ..Default::default()
             }),
             state: Some(ContainerState {
-                health: Some(bollard::secret::Health {
+                health: Some(bollard::models::Health {
                     status: Some(HealthStatusEnum::STARTING),
                     ..Default::default()
                 }),

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -8,7 +8,7 @@ use bollard::{
         ListContainersOptions, LogsOptions, RemoveContainerOptions, StartContainerOptions,
         StopContainerOptions,
     },
-    secret::{
+    models::{
         ContainerCreateBody, ContainerCreateResponse, ContainerInspectResponse, ContainerSummary,
     },
 };

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -3,13 +3,13 @@ use bollard::{
     container::LogOutput,
     errors::Error,
     exec::{CreateExecOptions, StartExecOptions, StartExecResults},
+    models::{
+        ContainerCreateBody, ContainerCreateResponse, ContainerInspectResponse, ContainerSummary,
+    },
     query_parameters::{
         CreateContainerOptions, CreateImageOptionsBuilder, InspectContainerOptions,
         ListContainersOptions, LogsOptions, RemoveContainerOptions, StartContainerOptions,
         StopContainerOptions,
-    },
-    models::{
-        ContainerCreateBody, ContainerCreateResponse, ContainerInspectResponse, ContainerSummary,
     },
 };
 use futures_util::{Stream, StreamExt, TryStreamExt};

--- a/src/models/create_deployment_options.rs
+++ b/src/models/create_deployment_options.rs
@@ -1,6 +1,6 @@
 use bollard::{
     query_parameters::CreateContainerOptions,
-    secret::{ContainerCreateBody, HostConfig, PortBinding},
+    models::{ContainerCreateBody, HostConfig, PortBinding},
 };
 use maplit::hashmap;
 use rand::RngExt;

--- a/src/models/create_deployment_options.rs
+++ b/src/models/create_deployment_options.rs
@@ -1,6 +1,6 @@
 use bollard::{
-    query_parameters::CreateContainerOptions,
     models::{ContainerCreateBody, HostConfig, PortBinding},
+    query_parameters::CreateContainerOptions,
 };
 use maplit::hashmap;
 use rand::RngExt;

--- a/src/models/deployment.rs
+++ b/src/models/deployment.rs
@@ -1,4 +1,4 @@
-use bollard::secret::ContainerInspectResponse;
+use bollard::models::ContainerInspectResponse;
 use semver::Version;
 
 use crate::models::{
@@ -176,7 +176,7 @@ fn is_seeding_true(value: impl AsRef<str>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bollard::secret::{
+    use bollard::models::{
         ContainerConfig, ContainerState, ContainerStateStatusEnum, MountPoint, NetworkSettings,
         PortBinding,
     };

--- a/src/models/environment_variables.rs
+++ b/src/models/environment_variables.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use bollard::secret::ContainerInspectResponse;
+use bollard::models::ContainerInspectResponse;
 
 use crate::models::CreationSource;
 
@@ -96,7 +96,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bollard::secret::{ContainerConfig, ContainerInspectResponse};
+    use bollard::models::{ContainerConfig, ContainerInspectResponse};
 
     #[test]
     fn test_from_container_inspect_response_no_config() {

--- a/src/models/labels.rs
+++ b/src/models/labels.rs
@@ -1,4 +1,4 @@
-use bollard::secret::ContainerInspectResponse;
+use bollard::models::ContainerInspectResponse;
 use semver::Version;
 
 use crate::models::{MongodbType, ParseMongodbTypeError};
@@ -81,7 +81,7 @@ impl TryFrom<&ContainerInspectResponse> for LocalDeploymentLabels {
 
 #[cfg(test)]
 mod tests {
-    use bollard::secret::ContainerConfig;
+    use bollard::models::ContainerConfig;
 
     use super::*;
 

--- a/src/models/port_binding.rs
+++ b/src/models/port_binding.rs
@@ -1,6 +1,6 @@
 use std::net::IpAddr;
 
-use bollard::secret::{ContainerInspectResponse, PortBinding};
+use bollard::models::{ContainerInspectResponse, PortBinding};
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -154,7 +154,7 @@ impl From<&MongoDBPortBinding> for PortBinding {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bollard::secret::NetworkSettings;
+    use bollard::models::NetworkSettings;
     use serde_json::json;
     use std::collections::HashMap;
 

--- a/src/models/state.rs
+++ b/src/models/state.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Display, str::FromStr};
 
-use bollard::secret::{ContainerInspectResponse, ContainerStateStatusEnum};
+use bollard::models::{ContainerInspectResponse, ContainerStateStatusEnum};
 
 /// The state of the container (from the Docker API)
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -169,7 +169,7 @@ mod tests {
 
     #[test]
     fn test_try_from_container_inspect_response_success() {
-        use bollard::secret::ContainerState;
+        use bollard::models::ContainerState;
 
         // Test successful conversion with a valid state
         let container_state = ContainerState {
@@ -198,7 +198,7 @@ mod tests {
 
     #[test]
     fn test_try_from_container_inspect_response_missing_status() {
-        use bollard::secret::ContainerState;
+        use bollard::models::ContainerState;
 
         // Test error case when state exists but status is None
         let container_inspect = ContainerInspectResponse {
@@ -213,7 +213,7 @@ mod tests {
 
     #[test]
     fn test_try_from_container_inspect_response_empty_status() {
-        use bollard::secret::ContainerState;
+        use bollard::models::ContainerState;
 
         // Test error case when status is EMPTY
         let container_state = ContainerState {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,4 +1,4 @@
-use bollard::secret::{
+use bollard::models::{
     ContainerConfig, ContainerInspectResponse, ContainerState, ContainerStateStatusEnum,
 };
 use maplit::hashmap;
@@ -23,10 +23,10 @@ pub fn create_container_inspect_response_with_auth(port: u16) -> ContainerInspec
             status: Some(ContainerStateStatusEnum::RUNNING),
             ..Default::default()
         }),
-        network_settings: Some(bollard::secret::NetworkSettings {
+        network_settings: Some(bollard::models::NetworkSettings {
             ports: Some(hashmap! {
                 "27017/tcp".to_string() => Some(vec![
-                    bollard::secret::PortBinding {
+                    bollard::models::PortBinding {
                         host_ip: Some("127.0.0.1".to_string()),
                         host_port: Some(port.to_string()),
                     }
@@ -54,10 +54,10 @@ pub fn create_container_inspect_response_no_auth(port: u16) -> ContainerInspectR
             status: Some(ContainerStateStatusEnum::RUNNING),
             ..Default::default()
         }),
-        network_settings: Some(bollard::secret::NetworkSettings {
+        network_settings: Some(bollard::models::NetworkSettings {
             ports: Some(hashmap! {
                 "27017/tcp".to_string() => Some(vec![
-                    bollard::secret::PortBinding {
+                    bollard::models::PortBinding {
                         host_ip: Some("127.0.0.1".to_string()),
                         host_port: Some(port.to_string()),
                     }


### PR DESCRIPTION
## What

bollard 0.20.2 made a breaking change: `bollard::secret` stopped re-exporting all container model types. In 0.20.1, `secret.rs` had `pub use crate::models::*;`. In 0.20.2 this became `use crate::models::*;` (private), so any code importing `bollard::secret::ContainerInspectResponse`, `bollard::secret::HealthStatusEnum`, etc. stopped compiling.

## Fix

Replace all `bollard::secret::*` imports with `bollard::models::*` across 21 files. This is the correct, documented path — bollard exports these types as `pub use bollard_stubs::models;` and the docs explicitly say to use `bollard::models` directly rather than `bollard_stubs` as a separate dependency.

The bollard version constraint is relaxed from `=0.20.1` to `0.20` to allow patch upgrades.

## Verification

`cargo check` and `cargo test --lib` both pass against bollard 0.20.2 (196 tests, 0 failures).

## Context

This unblocks the `mongodb-js/atlas-local-lib-js` repo, which currently has a workaround PR (#112) pinning bollard to `=0.20.1`. Once this fix is released, that pin can be removed.