### PR TITLE
feat: stop leaking bollard error types in public API

### DIFF
--- a/src/client/create_deployment/mod.rs
+++ b/src/client/create_deployment/mod.rs
@@ -137,7 +137,7 @@ impl<
             .create_container(Some(create_container_options), create_container_config)
             .await
             .map_err(|err| match err {
-                DockerError::Conflict { .. } => {
+                DockerError::Conflict => {
                     CreateDeploymentError::ContainerAlreadyExists(cluster_name.to_string())
                 }
                 _ => CreateDeploymentError::CreateContainer(err),
@@ -493,9 +493,7 @@ mod tests {
 
         // Set up expectations
         mock_docker.expect_pull_image().times(1).returning(|_, _| {
-            Err(DockerError::ServerError {
-                message: "Internal Server Error".to_string(),
-            })
+            Err(DockerError::ServerError)
         });
 
         let client = Client::new(mock_docker);
@@ -530,9 +528,7 @@ mod tests {
             .expect_create_container()
             .times(1)
             .returning(|_, _| {
-                Err(DockerError::Conflict {
-                    message: "Conflict".to_string(),
-                })
+                Err(DockerError::Conflict)
             });
 
         let client = Client::new(mock_docker);
@@ -569,9 +565,7 @@ mod tests {
             .expect_create_container()
             .times(1)
             .returning(|_, _| {
-                Err(DockerError::ServerError {
-                    message: "Internal Server Error".to_string(),
-                })
+                Err(DockerError::ServerError)
             });
 
         let client = Client::new(mock_docker);
@@ -616,9 +610,7 @@ mod tests {
             .expect_start_container()
             .times(1)
             .returning(|_, _| {
-                Err(DockerError::ServerError {
-                    message: "Internal Server Error".to_string(),
-                })
+                Err(DockerError::ServerError)
             });
 
         let client = Client::new(mock_docker);

--- a/src/client/create_deployment/mod.rs
+++ b/src/client/create_deployment/mod.rs
@@ -492,9 +492,10 @@ mod tests {
         };
 
         // Set up expectations
-        mock_docker.expect_pull_image().times(1).returning(|_, _| {
-            Err(DockerError::ServerError)
-        });
+        mock_docker
+            .expect_pull_image()
+            .times(1)
+            .returning(|_, _| Err(DockerError::ServerError));
 
         let client = Client::new(mock_docker);
 
@@ -527,9 +528,7 @@ mod tests {
         mock_docker
             .expect_create_container()
             .times(1)
-            .returning(|_, _| {
-                Err(DockerError::Conflict)
-            });
+            .returning(|_, _| Err(DockerError::Conflict));
 
         let client = Client::new(mock_docker);
 
@@ -564,9 +563,7 @@ mod tests {
         mock_docker
             .expect_create_container()
             .times(1)
-            .returning(|_, _| {
-                Err(DockerError::ServerError)
-            });
+            .returning(|_, _| Err(DockerError::ServerError));
 
         let client = Client::new(mock_docker);
 
@@ -609,9 +606,7 @@ mod tests {
         mock_docker
             .expect_start_container()
             .times(1)
-            .returning(|_, _| {
-                Err(DockerError::ServerError)
-            });
+            .returning(|_, _| Err(DockerError::ServerError));
 
         let client = Client::new(mock_docker);
 

--- a/src/client/create_deployment/mod.rs
+++ b/src/client/create_deployment/mod.rs
@@ -1,5 +1,4 @@
 use bollard::{
-    errors::Error::DockerResponseServerError,
     query_parameters::{CreateContainerOptions, StartContainerOptions},
     secret::ContainerCreateBody,
 };
@@ -9,7 +8,8 @@ use crate::{
     GetDeploymentError,
     client::Client,
     docker::{
-        DockerCreateContainer, DockerInspectContainer, DockerPullImage, DockerStartContainer,
+        DockerCreateContainer, DockerError, DockerInspectContainer, DockerPullImage,
+        DockerStartContainer,
     },
     models::{ATLAS_LOCAL_IMAGE, CreateDeploymentOptions, Deployment, WatchOptions},
 };
@@ -24,13 +24,13 @@ use progress::{CreateDeploymentProgressSender, create_progress_pairs};
 #[derive(Debug, thiserror::Error)]
 pub enum CreateDeploymentError {
     #[error("Failed to create container: {0}")]
-    CreateContainer(bollard::errors::Error),
+    CreateContainer(DockerError),
     #[error(transparent)]
     PullImage(#[from] PullImageError),
     #[error("Container already exists: {0}")]
     ContainerAlreadyExists(String),
     #[error("Failed to check status of started container: {0}")]
-    ContainerInspect(bollard::errors::Error),
+    ContainerInspect(DockerError),
     #[error("Created Deployment {0} is not healthy")]
     UnhealthyDeployment(String),
     #[error("Unable to get details for Deployment: {0}")]
@@ -137,9 +137,9 @@ impl<
             .create_container(Some(create_container_options), create_container_config)
             .await
             .map_err(|err| match err {
-                DockerResponseServerError {
-                    status_code: 409, ..
-                } => CreateDeploymentError::ContainerAlreadyExists(cluster_name.to_string()),
+                DockerError::Conflict { .. } => {
+                    CreateDeploymentError::ContainerAlreadyExists(cluster_name.to_string())
+                }
                 _ => CreateDeploymentError::CreateContainer(err),
             })?;
 
@@ -187,9 +187,9 @@ impl<
 mod tests {
     use super::*;
     use crate::client::WatchDeploymentError;
-    use crate::models::ImageTag;
+    use crate::docker::DockerError;
+    use crate::models::{ContainerHealthStatus, ImageTag};
     use bollard::{
-        errors::Error as BollardError,
         query_parameters::InspectContainerOptions,
         secret::{
             ContainerConfig, ContainerCreateResponse, ContainerInspectResponse, ContainerState,
@@ -205,7 +205,7 @@ mod tests {
         Docker {}
 
         impl DockerPullImage for Docker {
-            async fn pull_image(&self, image: &str, tag: &str) -> Result<(), BollardError>;
+            async fn pull_image(&self, image: &str, tag: &str) -> Result<(), DockerError>;
         }
 
         impl DockerCreateContainer for Docker {
@@ -213,7 +213,7 @@ mod tests {
                 &self,
                 options: Option<CreateContainerOptions>,
                 config: ContainerCreateBody,
-            ) -> Result<ContainerCreateResponse, BollardError>;
+            ) -> Result<ContainerCreateResponse, DockerError>;
         }
 
         impl DockerStartContainer for Docker {
@@ -221,7 +221,7 @@ mod tests {
                 &self,
                 container_id: &str,
                 options: Option<StartContainerOptions>,
-            ) -> Result<(), BollardError>;
+            ) -> Result<(), DockerError>;
         }
 
         impl DockerInspectContainer for Docker {
@@ -229,7 +229,7 @@ mod tests {
                 &self,
                 container_id: &str,
                 options: Option<InspectContainerOptions>,
-            ) -> Result<ContainerInspectResponse, BollardError>;
+            ) -> Result<ContainerInspectResponse, DockerError>;
         }
     }
 
@@ -493,8 +493,7 @@ mod tests {
 
         // Set up expectations
         mock_docker.expect_pull_image().times(1).returning(|_, _| {
-            Err(BollardError::DockerResponseServerError {
-                status_code: 500,
+            Err(DockerError::ServerError {
                 message: "Internal Server Error".to_string(),
             })
         });
@@ -531,8 +530,7 @@ mod tests {
             .expect_create_container()
             .times(1)
             .returning(|_, _| {
-                Err(BollardError::DockerResponseServerError {
-                    status_code: 409,
+                Err(DockerError::Conflict {
                     message: "Conflict".to_string(),
                 })
             });
@@ -571,8 +569,7 @@ mod tests {
             .expect_create_container()
             .times(1)
             .returning(|_, _| {
-                Err(BollardError::DockerResponseServerError {
-                    status_code: 500,
+                Err(DockerError::ServerError {
                     message: "Internal Server Error".to_string(),
                 })
             });
@@ -619,8 +616,7 @@ mod tests {
             .expect_start_container()
             .times(1)
             .returning(|_, _| {
-                Err(BollardError::DockerResponseServerError {
-                    status_code: 500,
+                Err(DockerError::ServerError {
                     message: "Internal Server Error".to_string(),
                 })
             });
@@ -948,7 +944,7 @@ mod tests {
                 status,
             }) => {
                 assert_eq!(deployment_name, "test-deployment");
-                assert_eq!(status, HealthStatusEnum::NONE);
+                assert_eq!(status, ContainerHealthStatus::None);
             }
             _ => panic!("Expected WatchDeployment error"),
         }
@@ -1014,7 +1010,7 @@ mod tests {
                 status,
             }) => {
                 assert_eq!(deployment_name, "test-deployment");
-                assert_eq!(status, HealthStatusEnum::NONE);
+                assert_eq!(status, ContainerHealthStatus::None);
             }
             _ => panic!("Expected WatchDeployment error"),
         }
@@ -1166,7 +1162,7 @@ mod tests {
                 status,
             }) => {
                 assert_eq!(deployment_name, "test-deployment");
-                assert_eq!(status, HealthStatusEnum::NONE);
+                assert_eq!(status, ContainerHealthStatus::None);
             }
             _ => panic!("Expected WatchDeployment error"),
         }

--- a/src/client/delete_deployment.rs
+++ b/src/client/delete_deployment.rs
@@ -2,19 +2,19 @@ use bollard::query_parameters::{RemoveContainerOptions, StopContainerOptions};
 
 use crate::{
     client::Client,
-    docker::{DockerInspectContainer, DockerRemoveContainer, DockerStopContainer},
+    docker::{DockerError, DockerInspectContainer, DockerRemoveContainer, DockerStopContainer},
 };
 
 use super::GetDeploymentError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum DeleteDeploymentError {
-    #[error("Failed to delete container: {0}")]
-    ContainerStop(bollard::errors::Error),
+    #[error("Failed to stop container: {0}")]
+    ContainerStop(DockerError),
     #[error("Failed to get deployment: {0}")]
     GetDeployment(#[from] GetDeploymentError),
-    #[error("Failed to delete remove: {0}")]
-    ContainerRemove(bollard::errors::Error),
+    #[error("Failed to remove container: {0}")]
+    ContainerRemove(DockerError),
 }
 
 impl<D: DockerStopContainer + DockerRemoveContainer + DockerInspectContainer> Client<D> {
@@ -44,9 +44,9 @@ impl<D: DockerStopContainer + DockerRemoveContainer + DockerInspectContainer> Cl
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::docker::DockerError;
     use bollard::{
-        errors::Error as BollardError, query_parameters::InspectContainerOptions,
-        secret::ContainerInspectResponse,
+        query_parameters::InspectContainerOptions, secret::ContainerInspectResponse,
     };
     use mockall::mock;
 
@@ -58,7 +58,7 @@ mod tests {
                 &self,
                 container_id: &str,
                 options: Option<StopContainerOptions>,
-            ) -> Result<(), BollardError>;
+            ) -> Result<(), DockerError>;
         }
 
         impl DockerRemoveContainer for Docker {
@@ -66,7 +66,7 @@ mod tests {
                 &self,
                 container_id: &str,
                 options: Option<RemoveContainerOptions>,
-            ) -> Result<(), BollardError>;
+            ) -> Result<(), DockerError>;
         }
 
         impl DockerInspectContainer for Docker {
@@ -74,7 +74,7 @@ mod tests {
                 &self,
                 container_id: &str,
                 options: Option<InspectContainerOptions>,
-            ) -> Result<ContainerInspectResponse, BollardError>;
+            ) -> Result<ContainerInspectResponse, DockerError>;
         }
     }
 
@@ -157,8 +157,7 @@ mod tests {
             .expect_inspect_container()
             .times(1)
             .returning(|_, _| {
-                Err(BollardError::DockerResponseServerError {
-                    status_code: 404,
+                Err(DockerError::NotFound {
                     message: "No such container".to_string(),
                 })
             });
@@ -191,8 +190,7 @@ mod tests {
             .expect_stop_container()
             .times(1)
             .returning(|_, _| {
-                Err(BollardError::DockerResponseServerError {
-                    status_code: 500,
+                Err(DockerError::ServerError {
                     message: "Internal Server Error".to_string(),
                 })
             });
@@ -230,8 +228,7 @@ mod tests {
             .expect_remove_container()
             .times(1)
             .returning(|_, _| {
-                Err(BollardError::DockerResponseServerError {
-                    status_code: 500,
+                Err(DockerError::ServerError {
                     message: "Internal Server Error".to_string(),
                 })
             });

--- a/src/client/delete_deployment.rs
+++ b/src/client/delete_deployment.rs
@@ -157,9 +157,7 @@ mod tests {
             .expect_inspect_container()
             .times(1)
             .returning(|_, _| {
-                Err(DockerError::NotFound {
-                    message: "No such container".to_string(),
-                })
+                Err(DockerError::NotFound)
             });
 
         let client = Client::new(mock_docker);
@@ -190,9 +188,7 @@ mod tests {
             .expect_stop_container()
             .times(1)
             .returning(|_, _| {
-                Err(DockerError::ServerError {
-                    message: "Internal Server Error".to_string(),
-                })
+                Err(DockerError::ServerError)
             });
 
         let client = Client::new(mock_docker);
@@ -228,9 +224,7 @@ mod tests {
             .expect_remove_container()
             .times(1)
             .returning(|_, _| {
-                Err(DockerError::ServerError {
-                    message: "Internal Server Error".to_string(),
-                })
+                Err(DockerError::ServerError)
             });
 
         let client = Client::new(mock_docker);

--- a/src/client/delete_deployment.rs
+++ b/src/client/delete_deployment.rs
@@ -45,9 +45,7 @@ impl<D: DockerStopContainer + DockerRemoveContainer + DockerInspectContainer> Cl
 mod tests {
     use super::*;
     use crate::docker::DockerError;
-    use bollard::{
-        query_parameters::InspectContainerOptions, secret::ContainerInspectResponse,
-    };
+    use bollard::{query_parameters::InspectContainerOptions, secret::ContainerInspectResponse};
     use mockall::mock;
 
     mock! {
@@ -156,9 +154,7 @@ mod tests {
         mock_docker
             .expect_inspect_container()
             .times(1)
-            .returning(|_, _| {
-                Err(DockerError::NotFound)
-            });
+            .returning(|_, _| Err(DockerError::NotFound));
 
         let client = Client::new(mock_docker);
 
@@ -187,9 +183,7 @@ mod tests {
         mock_docker
             .expect_stop_container()
             .times(1)
-            .returning(|_, _| {
-                Err(DockerError::ServerError)
-            });
+            .returning(|_, _| Err(DockerError::ServerError));
 
         let client = Client::new(mock_docker);
 
@@ -223,9 +217,7 @@ mod tests {
         mock_docker
             .expect_remove_container()
             .times(1)
-            .returning(|_, _| {
-                Err(DockerError::ServerError)
-            });
+            .returning(|_, _| Err(DockerError::ServerError));
 
         let client = Client::new(mock_docker);
 

--- a/src/client/get_connection_string.rs
+++ b/src/client/get_connection_string.rs
@@ -104,8 +104,8 @@ mod tests {
             create_container_inspect_response_no_auth, create_container_inspect_response_with_auth,
         },
     };
+    use crate::docker::DockerError;
     use bollard::{
-        errors::Error as BollardError,
         query_parameters::InspectContainerOptions,
         secret::{
             ContainerConfig, ContainerInspectResponse, ContainerState, ContainerStateStatusEnum,
@@ -122,7 +122,7 @@ mod tests {
                 &self,
                 container_id: &str,
                 options: Option<InspectContainerOptions>,
-            ) -> Result<ContainerInspectResponse, BollardError>;
+            ) -> Result<ContainerInspectResponse, DockerError>;
         }
 
         impl RunCommandInContainer for Docker {
@@ -206,8 +206,7 @@ mod tests {
             )
             .times(1)
             .returning(|_, _| {
-                Err(BollardError::DockerResponseServerError {
-                    status_code: 404,
+                Err(DockerError::NotFound {
                     message: "No such container".to_string(),
                 })
             });

--- a/src/client/get_connection_string.rs
+++ b/src/client/get_connection_string.rs
@@ -206,9 +206,7 @@ mod tests {
             )
             .times(1)
             .returning(|_, _| {
-                Err(DockerError::NotFound {
-                    message: "No such container".to_string(),
-                })
+                Err(DockerError::NotFound)
             });
 
         let client = Client::new(mock_docker);

--- a/src/client/get_connection_string.rs
+++ b/src/client/get_connection_string.rs
@@ -94,6 +94,7 @@ fn format_connection_string(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::docker::DockerError;
     use crate::{
         client::Client,
         docker::{
@@ -104,7 +105,6 @@ mod tests {
             create_container_inspect_response_no_auth, create_container_inspect_response_with_auth,
         },
     };
-    use crate::docker::DockerError;
     use bollard::{
         query_parameters::InspectContainerOptions,
         secret::{
@@ -205,9 +205,7 @@ mod tests {
                 mockall::predicate::eq(None::<InspectContainerOptions>),
             )
             .times(1)
-            .returning(|_, _| {
-                Err(DockerError::NotFound)
-            });
+            .returning(|_, _| Err(DockerError::NotFound));
 
         let client = Client::new(mock_docker);
         let container_id_or_name = "nonexistent-deployment".to_string();

--- a/src/client/get_deployment.rs
+++ b/src/client/get_deployment.rs
@@ -143,9 +143,7 @@ mod tests {
             )
             .times(1)
             .returning(|_, _| {
-                Err(DockerError::NotFound {
-                    message: "No such container".to_string(),
-                })
+                Err(DockerError::NotFound)
             });
 
         let client = Client::new(mock_docker);

--- a/src/client/get_deployment.rs
+++ b/src/client/get_deployment.rs
@@ -2,14 +2,14 @@ use bollard::query_parameters::InspectContainerOptions;
 
 use crate::{
     client::Client,
-    docker::DockerInspectContainer,
+    docker::{DockerError, DockerInspectContainer},
     models::{Deployment, IntoDeploymentError},
 };
 
 #[derive(Debug, thiserror::Error)]
 pub enum GetDeploymentError {
     #[error("Failed to inspect container: {0}")]
-    ContainerInspect(#[from] bollard::errors::Error),
+    ContainerInspect(#[from] DockerError),
     #[error("The container is not a local Atlas deployment: {0}")]
     IntoDeployment(#[from] IntoDeploymentError),
 }
@@ -38,12 +38,12 @@ impl<D: DockerInspectContainer> Client<D> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::{CreationSource, MongodbType, State};
-    use bollard::{
-        errors::Error as BollardError,
-        secret::{
-            ContainerConfig, ContainerInspectResponse, ContainerState, ContainerStateStatusEnum,
-        },
+    use crate::{
+        docker::DockerError,
+        models::{CreationSource, MongodbType, State},
+    };
+    use bollard::secret::{
+        ContainerConfig, ContainerInspectResponse, ContainerState, ContainerStateStatusEnum,
     };
     use maplit::hashmap;
     use mockall::mock;
@@ -58,7 +58,7 @@ mod tests {
                 &self,
                 container_id: &str,
                 options: Option<InspectContainerOptions>,
-            ) -> Result<ContainerInspectResponse, BollardError>;
+            ) -> Result<ContainerInspectResponse, DockerError>;
         }
     }
 
@@ -143,8 +143,7 @@ mod tests {
             )
             .times(1)
             .returning(|_, _| {
-                Err(BollardError::DockerResponseServerError {
-                    status_code: 404,
+                Err(DockerError::NotFound {
                     message: "No such container".to_string(),
                 })
             });

--- a/src/client/get_deployment.rs
+++ b/src/client/get_deployment.rs
@@ -142,9 +142,7 @@ mod tests {
                 mockall::predicate::eq(None::<InspectContainerOptions>),
             )
             .times(1)
-            .returning(|_, _| {
-                Err(DockerError::NotFound)
-            });
+            .returning(|_, _| Err(DockerError::NotFound));
 
         let client = Client::new(mock_docker);
 

--- a/src/client/get_deployment_id.rs
+++ b/src/client/get_deployment_id.rs
@@ -81,8 +81,8 @@ impl<D: DockerInspectContainer + RunCommandInContainer> Client<D> {
 mod tests {
     use super::*;
     use crate::{client::get_deployment::GetDeploymentError, docker::CommandOutput};
+    use crate::docker::DockerError;
     use bollard::{
-        errors::Error as BollardError,
         query_parameters::InspectContainerOptions,
         secret::{
             ContainerConfig, ContainerInspectResponse, ContainerState, ContainerStateStatusEnum,
@@ -99,7 +99,7 @@ mod tests {
                 &self,
                 container_id: &str,
                 options: Option<InspectContainerOptions>,
-            ) -> Result<ContainerInspectResponse, BollardError>;
+            ) -> Result<ContainerInspectResponse, DockerError>;
         }
 
         impl RunCommandInContainer for Docker {
@@ -329,8 +329,7 @@ mod tests {
             )
             .times(1)
             .returning(|_, _| {
-                Err(BollardError::DockerResponseServerError {
-                    status_code: 404,
+                Err(DockerError::NotFound {
                     message: "No such container".to_string(),
                 })
             });
@@ -380,8 +379,7 @@ mod tests {
             .times(1)
             .returning(|_, _| {
                 Err(RunCommandInContainerError::CreateExec(
-                    BollardError::DockerResponseServerError {
-                        status_code: 500,
+                    DockerError::ServerError {
                         message: "Failed to read file".to_string(),
                     },
                 ))
@@ -432,8 +430,7 @@ mod tests {
             .times(1)
             .returning(|_, _| {
                 Err(RunCommandInContainerError::StartExec(
-                    BollardError::DockerResponseServerError {
-                        status_code: 500,
+                    DockerError::ServerError {
                         message: "Failed to start exec".to_string(),
                     },
                 ))
@@ -596,8 +593,7 @@ mod tests {
             .times(1)
             .returning(|_, _| {
                 Err(RunCommandInContainerError::GetOutputError(
-                    BollardError::DockerResponseServerError {
-                        status_code: 500,
+                    DockerError::ServerError {
                         message: "Failed to get output".to_string(),
                     },
                 ))

--- a/src/client/get_deployment_id.rs
+++ b/src/client/get_deployment_id.rs
@@ -80,8 +80,8 @@ impl<D: DockerInspectContainer + RunCommandInContainer> Client<D> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{client::get_deployment::GetDeploymentError, docker::CommandOutput};
     use crate::docker::DockerError;
+    use crate::{client::get_deployment::GetDeploymentError, docker::CommandOutput};
     use bollard::{
         query_parameters::InspectContainerOptions,
         secret::{
@@ -328,9 +328,7 @@ mod tests {
                 eq(None::<InspectContainerOptions>),
             )
             .times(1)
-            .returning(|_, _| {
-                Err(DockerError::NotFound)
-            });
+            .returning(|_, _| Err(DockerError::NotFound));
 
         let client = Client::new(mock_docker);
 
@@ -377,7 +375,7 @@ mod tests {
             .times(1)
             .returning(|_, _| {
                 Err(RunCommandInContainerError::CreateExec(
-                    DockerError::ServerError
+                    DockerError::ServerError,
                 ))
             });
 
@@ -426,7 +424,7 @@ mod tests {
             .times(1)
             .returning(|_, _| {
                 Err(RunCommandInContainerError::StartExec(
-                    DockerError::ServerError
+                    DockerError::ServerError,
                 ))
             });
 
@@ -587,7 +585,7 @@ mod tests {
             .times(1)
             .returning(|_, _| {
                 Err(RunCommandInContainerError::GetOutputError(
-                    DockerError::ServerError
+                    DockerError::ServerError,
                 ))
             });
 

--- a/src/client/get_deployment_id.rs
+++ b/src/client/get_deployment_id.rs
@@ -329,9 +329,7 @@ mod tests {
             )
             .times(1)
             .returning(|_, _| {
-                Err(DockerError::NotFound {
-                    message: "No such container".to_string(),
-                })
+                Err(DockerError::NotFound)
             });
 
         let client = Client::new(mock_docker);
@@ -379,9 +377,7 @@ mod tests {
             .times(1)
             .returning(|_, _| {
                 Err(RunCommandInContainerError::CreateExec(
-                    DockerError::ServerError {
-                        message: "Failed to read file".to_string(),
-                    },
+                    DockerError::ServerError
                 ))
             });
 
@@ -430,9 +426,7 @@ mod tests {
             .times(1)
             .returning(|_, _| {
                 Err(RunCommandInContainerError::StartExec(
-                    DockerError::ServerError {
-                        message: "Failed to start exec".to_string(),
-                    },
+                    DockerError::ServerError
                 ))
             });
 
@@ -593,9 +587,7 @@ mod tests {
             .times(1)
             .returning(|_, _| {
                 Err(RunCommandInContainerError::GetOutputError(
-                    DockerError::ServerError {
-                        message: "Failed to get output".to_string(),
-                    },
+                    DockerError::ServerError
                 ))
             });
 

--- a/src/client/list_deployments.rs
+++ b/src/client/list_deployments.rs
@@ -47,7 +47,10 @@ impl<D: DockerListContainers + DockerInspectContainer> Client<D> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{docker::DockerError, models::{MongodbType, State}};
+    use crate::{
+        docker::DockerError,
+        models::{MongodbType, State},
+    };
     use bollard::{
         query_parameters::{InspectContainerOptions, ListContainersOptions},
         secret::{
@@ -200,9 +203,7 @@ mod tests {
         mock_docker
             .expect_list_containers()
             .times(1)
-            .returning(|_| {
-                Err(DockerError::ServerError)
-            });
+            .returning(|_| Err(DockerError::ServerError));
 
         let client = Client::new(mock_docker);
 
@@ -237,9 +238,7 @@ mod tests {
                 mockall::predicate::eq(None::<InspectContainerOptions>),
             )
             .times(1)
-            .returning(|_, _| {
-                Err(DockerError::NotFound)
-            });
+            .returning(|_, _| Err(DockerError::NotFound));
 
         let client = Client::new(mock_docker);
 

--- a/src/client/list_deployments.rs
+++ b/src/client/list_deployments.rs
@@ -201,9 +201,7 @@ mod tests {
             .expect_list_containers()
             .times(1)
             .returning(|_| {
-                Err(DockerError::ServerError {
-                    message: "Internal Server Error".to_string(),
-                })
+                Err(DockerError::ServerError)
             });
 
         let client = Client::new(mock_docker);
@@ -240,9 +238,7 @@ mod tests {
             )
             .times(1)
             .returning(|_, _| {
-                Err(DockerError::NotFound {
-                    message: "No such container".to_string(),
-                })
+                Err(DockerError::NotFound)
             });
 
         let client = Client::new(mock_docker);

--- a/src/client/list_deployments.rs
+++ b/src/client/list_deployments.rs
@@ -47,9 +47,8 @@ impl<D: DockerListContainers + DockerInspectContainer> Client<D> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::{MongodbType, State};
+    use crate::{docker::DockerError, models::{MongodbType, State}};
     use bollard::{
-        errors::Error as BollardError,
         query_parameters::{InspectContainerOptions, ListContainersOptions},
         secret::{
             ContainerConfig, ContainerInspectResponse, ContainerState, ContainerStateStatusEnum,
@@ -66,7 +65,7 @@ mod tests {
             async fn list_containers(
                 &self,
                 options: Option<ListContainersOptions>,
-            ) -> Result<Vec<ContainerSummary>, BollardError>;
+            ) -> Result<Vec<ContainerSummary>, DockerError>;
         }
 
         impl DockerInspectContainer for Docker {
@@ -74,7 +73,7 @@ mod tests {
                 &self,
                 container_id: &str,
                 options: Option<InspectContainerOptions>,
-            ) -> Result<ContainerInspectResponse, BollardError>;
+            ) -> Result<ContainerInspectResponse, DockerError>;
         }
     }
 
@@ -202,8 +201,7 @@ mod tests {
             .expect_list_containers()
             .times(1)
             .returning(|_| {
-                Err(BollardError::DockerResponseServerError {
-                    status_code: 500,
+                Err(DockerError::ServerError {
                     message: "Internal Server Error".to_string(),
                 })
             });
@@ -242,8 +240,7 @@ mod tests {
             )
             .times(1)
             .returning(|_, _| {
-                Err(BollardError::DockerResponseServerError {
-                    status_code: 404,
+                Err(DockerError::NotFound {
                     message: "No such container".to_string(),
                 })
             });

--- a/src/client/pause_deployment.rs
+++ b/src/client/pause_deployment.rs
@@ -34,17 +34,15 @@ impl<D: DockerPauseContainer + DockerInspectContainer> Client<D> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bollard::{
-        errors::Error as BollardError, query_parameters::InspectContainerOptions,
-        secret::ContainerInspectResponse,
-    };
+    use crate::docker::DockerError;
+    use bollard::{query_parameters::InspectContainerOptions, secret::ContainerInspectResponse};
     use mockall::mock;
 
     mock! {
         Docker {}
 
         impl DockerPauseContainer for Docker {
-            async fn pause_container(&self, container_id: &str) -> Result<(), BollardError>;
+            async fn pause_container(&self, container_id: &str) -> Result<(), DockerError>;
         }
 
         impl DockerInspectContainer for Docker {
@@ -52,7 +50,7 @@ mod tests {
                 &self,
                 container_id: &str,
                 options: Option<InspectContainerOptions>,
-            ) -> Result<ContainerInspectResponse, BollardError>;
+            ) -> Result<ContainerInspectResponse, DockerError>;
         }
     }
 
@@ -123,8 +121,7 @@ mod tests {
             .expect_inspect_container()
             .times(1)
             .returning(|_, _| {
-                Err(BollardError::DockerResponseServerError {
-                    status_code: 404,
+                Err(DockerError::NotFound {
                     message: "No such container".to_string(),
                 })
             });
@@ -157,8 +154,7 @@ mod tests {
             .expect_pause_container()
             .times(1)
             .returning(|_| {
-                Err(BollardError::DockerResponseServerError {
-                    status_code: 500,
+                Err(DockerError::ServerError {
                     message: "Internal Server Error".to_string(),
                 })
             });

--- a/src/client/pause_deployment.rs
+++ b/src/client/pause_deployment.rs
@@ -121,9 +121,7 @@ mod tests {
             .expect_inspect_container()
             .times(1)
             .returning(|_, _| {
-                Err(DockerError::NotFound {
-                    message: "No such container".to_string(),
-                })
+                Err(DockerError::NotFound)
             });
 
         let client = Client::new(mock_docker);
@@ -154,9 +152,7 @@ mod tests {
             .expect_pause_container()
             .times(1)
             .returning(|_| {
-                Err(DockerError::ServerError {
-                    message: "Internal Server Error".to_string(),
-                })
+                Err(DockerError::ServerError)
             });
 
         let client = Client::new(mock_docker);

--- a/src/client/pause_deployment.rs
+++ b/src/client/pause_deployment.rs
@@ -120,9 +120,7 @@ mod tests {
         mock_docker
             .expect_inspect_container()
             .times(1)
-            .returning(|_, _| {
-                Err(DockerError::NotFound)
-            });
+            .returning(|_, _| Err(DockerError::NotFound));
 
         let client = Client::new(mock_docker);
 
@@ -151,9 +149,7 @@ mod tests {
         mock_docker
             .expect_pause_container()
             .times(1)
-            .returning(|_| {
-                Err(DockerError::ServerError)
-            });
+            .returning(|_| Err(DockerError::ServerError));
 
         let client = Client::new(mock_docker);
 

--- a/src/client/pull_image.rs
+++ b/src/client/pull_image.rs
@@ -74,9 +74,7 @@ mod tests {
             )
             .times(1)
             .returning(|_, _| {
-                Err(DockerError::NotFound {
-                    message: "Tag not found".to_string(),
-                })
+                Err(DockerError::NotFound)
             });
 
         let client = Client::new(mock_docker);

--- a/src/client/pull_image.rs
+++ b/src/client/pull_image.rs
@@ -1,8 +1,11 @@
-use crate::{client::Client, docker::DockerPullImage};
+use crate::{
+    client::Client,
+    docker::{DockerError, DockerPullImage},
+};
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
 #[error("Failed to pull image: {0}")]
-pub struct PullImageError(#[from] bollard::errors::Error);
+pub struct PullImageError(#[from] DockerError);
 
 impl<D: DockerPullImage> Client<D> {
     /// Pulls the Atlas Local image.
@@ -20,14 +23,14 @@ impl<D: DockerPullImage> Client<D> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bollard::errors::Error as BollardError;
+    use crate::docker::DockerError;
     use mockall::mock;
 
     mock! {
         Docker {}
 
         impl DockerPullImage for Docker {
-            async fn pull_image(&self, image: &str, tag: &str) -> Result<(), BollardError>;
+            async fn pull_image(&self, image: &str, tag: &str) -> Result<(), DockerError>;
         }
     }
 
@@ -71,8 +74,7 @@ mod tests {
             )
             .times(1)
             .returning(|_, _| {
-                Err(BollardError::DockerResponseServerError {
-                    status_code: 404,
+                Err(DockerError::NotFound {
                     message: "Tag not found".to_string(),
                 })
             });

--- a/src/client/pull_image.rs
+++ b/src/client/pull_image.rs
@@ -73,9 +73,7 @@ mod tests {
                 mockall::predicate::eq("invalid-tag"),
             )
             .times(1)
-            .returning(|_, _| {
-                Err(DockerError::NotFound)
-            });
+            .returning(|_, _| Err(DockerError::NotFound));
 
         let client = Client::new(mock_docker);
 

--- a/src/client/start_deployment.rs
+++ b/src/client/start_deployment.rs
@@ -36,10 +36,8 @@ impl<D: DockerStartContainer + DockerInspectContainer> Client<D> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bollard::{
-        errors::Error as BollardError, query_parameters::InspectContainerOptions,
-        secret::ContainerInspectResponse,
-    };
+    use crate::docker::DockerError;
+    use bollard::{query_parameters::InspectContainerOptions, secret::ContainerInspectResponse};
     use mockall::mock;
 
     mock! {
@@ -50,7 +48,7 @@ mod tests {
                 &self,
                 container_id: &str,
                 options: Option<StartContainerOptions>,
-            ) -> Result<(), BollardError>;
+            ) -> Result<(), DockerError>;
         }
 
         impl DockerInspectContainer for Docker {
@@ -58,7 +56,7 @@ mod tests {
                 &self,
                 container_id: &str,
                 options: Option<InspectContainerOptions>,
-            ) -> Result<ContainerInspectResponse, BollardError>;
+            ) -> Result<ContainerInspectResponse, DockerError>;
         }
     }
 
@@ -132,8 +130,7 @@ mod tests {
             .expect_inspect_container()
             .times(1)
             .returning(|_, _| {
-                Err(BollardError::DockerResponseServerError {
-                    status_code: 404,
+                Err(DockerError::NotFound {
                     message: "No such container".to_string(),
                 })
             });
@@ -166,8 +163,7 @@ mod tests {
             .expect_start_container()
             .times(1)
             .returning(|_, _| {
-                Err(BollardError::DockerResponseServerError {
-                    status_code: 500,
+                Err(DockerError::ServerError {
                     message: "Internal Server Error".to_string(),
                 })
             });

--- a/src/client/start_deployment.rs
+++ b/src/client/start_deployment.rs
@@ -129,9 +129,7 @@ mod tests {
         mock_docker
             .expect_inspect_container()
             .times(1)
-            .returning(|_, _| {
-                Err(DockerError::NotFound)
-            });
+            .returning(|_, _| Err(DockerError::NotFound));
 
         let client = Client::new(mock_docker);
 
@@ -160,9 +158,7 @@ mod tests {
         mock_docker
             .expect_start_container()
             .times(1)
-            .returning(|_, _| {
-                Err(DockerError::ServerError)
-            });
+            .returning(|_, _| Err(DockerError::ServerError));
 
         let client = Client::new(mock_docker);
 

--- a/src/client/start_deployment.rs
+++ b/src/client/start_deployment.rs
@@ -130,9 +130,7 @@ mod tests {
             .expect_inspect_container()
             .times(1)
             .returning(|_, _| {
-                Err(DockerError::NotFound {
-                    message: "No such container".to_string(),
-                })
+                Err(DockerError::NotFound)
             });
 
         let client = Client::new(mock_docker);
@@ -163,9 +161,7 @@ mod tests {
             .expect_start_container()
             .times(1)
             .returning(|_, _| {
-                Err(DockerError::ServerError {
-                    message: "Internal Server Error".to_string(),
-                })
+                Err(DockerError::ServerError)
             });
 
         let client = Client::new(mock_docker);

--- a/src/client/stop_deployment.rs
+++ b/src/client/stop_deployment.rs
@@ -129,9 +129,7 @@ mod tests {
         mock_docker
             .expect_inspect_container()
             .times(1)
-            .returning(|_, _| {
-                Err(DockerError::NotFound)
-            });
+            .returning(|_, _| Err(DockerError::NotFound));
 
         let client = Client::new(mock_docker);
 
@@ -160,9 +158,7 @@ mod tests {
         mock_docker
             .expect_stop_container()
             .times(1)
-            .returning(|_, _| {
-                Err(DockerError::ServerError)
-            });
+            .returning(|_, _| Err(DockerError::ServerError));
 
         let client = Client::new(mock_docker);
 

--- a/src/client/stop_deployment.rs
+++ b/src/client/stop_deployment.rs
@@ -36,10 +36,8 @@ impl<D: DockerStopContainer + DockerInspectContainer> Client<D> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bollard::{
-        errors::Error as BollardError, query_parameters::InspectContainerOptions,
-        secret::ContainerInspectResponse,
-    };
+    use crate::docker::DockerError;
+    use bollard::{query_parameters::InspectContainerOptions, secret::ContainerInspectResponse};
     use mockall::mock;
 
     mock! {
@@ -50,7 +48,7 @@ mod tests {
                 &self,
                 container_id: &str,
                 options: Option<StopContainerOptions>,
-            ) -> Result<(), BollardError>;
+            ) -> Result<(), DockerError>;
         }
 
         impl DockerInspectContainer for Docker {
@@ -58,7 +56,7 @@ mod tests {
                 &self,
                 container_id: &str,
                 options: Option<InspectContainerOptions>,
-            ) -> Result<ContainerInspectResponse, BollardError>;
+            ) -> Result<ContainerInspectResponse, DockerError>;
         }
     }
 
@@ -132,8 +130,7 @@ mod tests {
             .expect_inspect_container()
             .times(1)
             .returning(|_, _| {
-                Err(BollardError::DockerResponseServerError {
-                    status_code: 404,
+                Err(DockerError::NotFound {
                     message: "No such container".to_string(),
                 })
             });
@@ -166,8 +163,7 @@ mod tests {
             .expect_stop_container()
             .times(1)
             .returning(|_, _| {
-                Err(BollardError::DockerResponseServerError {
-                    status_code: 500,
+                Err(DockerError::ServerError {
                     message: "Internal Server Error".to_string(),
                 })
             });

--- a/src/client/stop_deployment.rs
+++ b/src/client/stop_deployment.rs
@@ -130,9 +130,7 @@ mod tests {
             .expect_inspect_container()
             .times(1)
             .returning(|_, _| {
-                Err(DockerError::NotFound {
-                    message: "No such container".to_string(),
-                })
+                Err(DockerError::NotFound)
             });
 
         let client = Client::new(mock_docker);
@@ -163,9 +161,7 @@ mod tests {
             .expect_stop_container()
             .times(1)
             .returning(|_, _| {
-                Err(DockerError::ServerError {
-                    message: "Internal Server Error".to_string(),
-                })
+                Err(DockerError::ServerError)
             });
 
         let client = Client::new(mock_docker);

--- a/src/client/unpause_deployment.rs
+++ b/src/client/unpause_deployment.rs
@@ -120,9 +120,7 @@ mod tests {
         mock_docker
             .expect_inspect_container()
             .times(1)
-            .returning(|_, _| {
-                Err(DockerError::NotFound)
-            });
+            .returning(|_, _| Err(DockerError::NotFound));
 
         let client = Client::new(mock_docker);
 
@@ -151,9 +149,7 @@ mod tests {
         mock_docker
             .expect_unpause_container()
             .times(1)
-            .returning(|_| {
-                Err(DockerError::ServerError)
-            });
+            .returning(|_| Err(DockerError::ServerError));
 
         let client = Client::new(mock_docker);
 

--- a/src/client/unpause_deployment.rs
+++ b/src/client/unpause_deployment.rs
@@ -121,9 +121,7 @@ mod tests {
             .expect_inspect_container()
             .times(1)
             .returning(|_, _| {
-                Err(DockerError::NotFound {
-                    message: "No such container".to_string(),
-                })
+                Err(DockerError::NotFound)
             });
 
         let client = Client::new(mock_docker);
@@ -154,9 +152,7 @@ mod tests {
             .expect_unpause_container()
             .times(1)
             .returning(|_| {
-                Err(DockerError::ServerError {
-                    message: "Internal Server Error".to_string(),
-                })
+                Err(DockerError::ServerError)
             });
 
         let client = Client::new(mock_docker);

--- a/src/client/unpause_deployment.rs
+++ b/src/client/unpause_deployment.rs
@@ -34,17 +34,15 @@ impl<D: DockerUnpauseContainer + DockerInspectContainer> Client<D> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bollard::{
-        errors::Error as BollardError, query_parameters::InspectContainerOptions,
-        secret::ContainerInspectResponse,
-    };
+    use crate::docker::DockerError;
+    use bollard::{query_parameters::InspectContainerOptions, secret::ContainerInspectResponse};
     use mockall::mock;
 
     mock! {
         Docker {}
 
         impl DockerUnpauseContainer for Docker {
-            async fn unpause_container(&self, container_id: &str) -> Result<(), BollardError>;
+            async fn unpause_container(&self, container_id: &str) -> Result<(), DockerError>;
         }
 
         impl DockerInspectContainer for Docker {
@@ -52,7 +50,7 @@ mod tests {
                 &self,
                 container_id: &str,
                 options: Option<InspectContainerOptions>,
-            ) -> Result<ContainerInspectResponse, BollardError>;
+            ) -> Result<ContainerInspectResponse, DockerError>;
         }
     }
 
@@ -123,8 +121,7 @@ mod tests {
             .expect_inspect_container()
             .times(1)
             .returning(|_, _| {
-                Err(BollardError::DockerResponseServerError {
-                    status_code: 404,
+                Err(DockerError::NotFound {
                     message: "No such container".to_string(),
                 })
             });
@@ -157,8 +154,7 @@ mod tests {
             .expect_unpause_container()
             .times(1)
             .returning(|_| {
-                Err(BollardError::DockerResponseServerError {
-                    status_code: 500,
+                Err(DockerError::ServerError {
                     message: "Internal Server Error".to_string(),
                 })
             });

--- a/src/client/watch_deployment.rs
+++ b/src/client/watch_deployment.rs
@@ -1,19 +1,22 @@
 use bollard::query_parameters::InspectContainerOptions;
-use bollard::secret::HealthStatusEnum;
 use tokio::time;
 
-use crate::{client::Client, docker::DockerInspectContainer, models::WatchOptions};
+use crate::{
+    client::Client,
+    docker::{DockerError, DockerInspectContainer},
+    models::{ContainerHealthStatus, WatchOptions},
+};
 
 #[derive(Debug, thiserror::Error)]
 pub enum WatchDeploymentError {
     #[error("Failed to inspect container: {0}")]
-    ContainerInspect(#[from] bollard::errors::Error),
+    ContainerInspect(#[from] DockerError),
     #[error("Timeout while waiting for container {deployment_name} to become healthy")]
     Timeout { deployment_name: String },
     #[error("Deployment {deployment_name} is not healthy [status: {status}]")]
     UnhealthyDeployment {
         deployment_name: String,
-        status: HealthStatusEnum,
+        status: ContainerHealthStatus,
     },
 }
 
@@ -75,7 +78,7 @@ impl<D: DockerInspectContainer> Client<D> {
     ) -> Result<(), WatchDeploymentError> {
         // Loop until the container is healthy
         loop {
-            let mut status = self
+            let mut status: ContainerHealthStatus = self
                 .docker
                 .inspect_container(deployment_name, None::<InspectContainerOptions>)
                 .await
@@ -83,22 +86,25 @@ impl<D: DockerInspectContainer> Client<D> {
                 .state
                 .and_then(|s| s.health)
                 .and_then(|h| h.status)
+                .map(ContainerHealthStatus::from)
                 .ok_or_else(|| WatchDeploymentError::UnhealthyDeployment {
                     deployment_name: deployment_name.to_string(),
-                    status: HealthStatusEnum::NONE,
+                    status: ContainerHealthStatus::None,
                 })?;
 
             // If allow_unhealthy_initial_state is set then we handle it as a starting state
-            if options.allow_unhealthy_initial_state && status == HealthStatusEnum::UNHEALTHY {
-                status = HealthStatusEnum::STARTING;
+            if options.allow_unhealthy_initial_state && status == ContainerHealthStatus::Unhealthy {
+                status = ContainerHealthStatus::Starting;
             }
 
             match status {
-                HealthStatusEnum::HEALTHY => return Ok(()),
-                HealthStatusEnum::STARTING => {
+                ContainerHealthStatus::Healthy => return Ok(()),
+                ContainerHealthStatus::Starting => {
                     time::sleep(std::time::Duration::from_secs(1)).await;
                 }
-                HealthStatusEnum::NONE | HealthStatusEnum::EMPTY | HealthStatusEnum::UNHEALTHY => {
+                ContainerHealthStatus::None
+                | ContainerHealthStatus::Empty
+                | ContainerHealthStatus::Unhealthy => {
                     return Err(WatchDeploymentError::UnhealthyDeployment {
                         deployment_name: deployment_name.to_string(),
                         status,
@@ -112,12 +118,10 @@ impl<D: DockerInspectContainer> Client<D> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bollard::{
-        errors::Error as BollardError,
-        secret::{
-            ContainerConfig, ContainerInspectResponse, ContainerState, ContainerStateStatusEnum,
-            HealthStatusEnum,
-        },
+    use crate::docker::DockerError;
+    use bollard::secret::{
+        ContainerConfig, ContainerInspectResponse, ContainerState, ContainerStateStatusEnum,
+        HealthStatusEnum,
     };
     use maplit::hashmap;
     use mockall::mock;
@@ -131,7 +135,7 @@ mod tests {
                 &self,
                 container_id: &str,
                 options: Option<InspectContainerOptions>,
-            ) -> Result<ContainerInspectResponse, BollardError>;
+            ) -> Result<ContainerInspectResponse, DockerError>;
         }
     }
 
@@ -402,7 +406,7 @@ mod tests {
                 status,
             } => {
                 assert_eq!(deployment_name, "test-deployment");
-                assert_eq!(status, HealthStatusEnum::NONE);
+                assert_eq!(status, ContainerHealthStatus::None);
             }
             _ => panic!("Expected UnhealthyDeployment error"),
         }
@@ -438,7 +442,7 @@ mod tests {
                 status,
             } => {
                 assert_eq!(deployment_name, "test-deployment");
-                assert_eq!(status, HealthStatusEnum::NONE);
+                assert_eq!(status, ContainerHealthStatus::None);
             }
             _ => panic!("Expected UnhealthyDeployment error"),
         }
@@ -458,8 +462,7 @@ mod tests {
             )
             .times(1)
             .returning(|_, _| {
-                Err(BollardError::DockerResponseServerError {
-                    status_code: 404,
+                Err(DockerError::NotFound {
                     message: "No such container".to_string(),
                 })
             });

--- a/src/client/watch_deployment.rs
+++ b/src/client/watch_deployment.rs
@@ -462,9 +462,7 @@ mod tests {
             )
             .times(1)
             .returning(|_, _| {
-                Err(DockerError::NotFound {
-                    message: "No such container".to_string(),
-                })
+                Err(DockerError::NotFound)
             });
 
         let client = Client::new(mock_docker);

--- a/src/client/watch_deployment.rs
+++ b/src/client/watch_deployment.rs
@@ -461,9 +461,7 @@ mod tests {
                 mockall::predicate::eq(None::<InspectContainerOptions>),
             )
             .times(1)
-            .returning(|_, _| {
-                Err(DockerError::NotFound)
-            });
+            .returning(|_, _| Err(DockerError::NotFound));
 
         let client = Client::new(mock_docker);
 

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -41,21 +41,22 @@ pub enum DockerError {
 impl From<bollard::errors::Error> for DockerError {
     fn from(err: bollard::errors::Error) -> Self {
         match err {
-            bollard::errors::Error::DockerResponseServerError { status_code, message } => {
-                match status_code {
-                    304 => DockerError::NotModified,
-                    400 => DockerError::BadRequest,
-                    401 => DockerError::Unauthorized,
-                    403 => DockerError::Forbidden,
-                    404 => DockerError::NotFound,
-                    409 => DockerError::Conflict,
-                    500 => DockerError::ServerError,
-                    _ => DockerError::Other {
-                        status_code: Some(status_code),
-                        message,
-                    },
-                }
-            }
+            bollard::errors::Error::DockerResponseServerError {
+                status_code,
+                message,
+            } => match status_code {
+                304 => DockerError::NotModified,
+                400 => DockerError::BadRequest,
+                401 => DockerError::Unauthorized,
+                403 => DockerError::Forbidden,
+                404 => DockerError::NotFound,
+                409 => DockerError::Conflict,
+                500 => DockerError::ServerError,
+                _ => DockerError::Other {
+                    status_code: Some(status_code),
+                    message,
+                },
+            },
             _ => DockerError::Other {
                 status_code: None,
                 message: err.to_string(),

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -432,7 +432,10 @@ mod tests {
 
     #[test]
     fn test_docker_error_display() {
-        assert_eq!(DockerError::NotModified.to_string(), "resource not modified");
+        assert_eq!(
+            DockerError::NotModified.to_string(),
+            "resource not modified"
+        );
         assert_eq!(DockerError::BadRequest.to_string(), "bad request");
         assert_eq!(DockerError::Unauthorized.to_string(), "unauthorized");
         assert_eq!(DockerError::Forbidden.to_string(), "forbidden");

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1,7 +1,6 @@
 use bollard::{
     Docker,
     container::LogOutput,
-    errors::Error,
     exec::{CreateExecOptions, StartExecOptions, StartExecResults},
     query_parameters::{
         CreateContainerOptions, CreateImageOptionsBuilder, InspectContainerOptions,
@@ -14,12 +13,76 @@ use bollard::{
 };
 use futures_util::{Stream, StreamExt, TryStreamExt};
 
+use crate::models::ContainerHealthStatus;
+
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum DockerError {
+    #[error("resource not modified: {message}")]
+    NotModified { message: String },
+    #[error("bad request: {message}")]
+    BadRequest { message: String },
+    #[error("unauthorized: {message}")]
+    Unauthorized { message: String },
+    #[error("forbidden: {message}")]
+    Forbidden { message: String },
+    #[error("not found: {message}")]
+    NotFound { message: String },
+    #[error("conflict: {message}")]
+    Conflict { message: String },
+    #[error("internal server error: {message}")]
+    ServerError { message: String },
+    #[error("docker error (status {status_code:?}): {message}")]
+    Other {
+        status_code: Option<u16>,
+        message: String,
+    },
+}
+
+impl From<bollard::errors::Error> for DockerError {
+    fn from(err: bollard::errors::Error) -> Self {
+        match err {
+            bollard::errors::Error::DockerResponseServerError {
+                status_code,
+                message,
+            } => match status_code {
+                304 => DockerError::NotModified { message },
+                400 => DockerError::BadRequest { message },
+                401 => DockerError::Unauthorized { message },
+                403 => DockerError::Forbidden { message },
+                404 => DockerError::NotFound { message },
+                409 => DockerError::Conflict { message },
+                500 => DockerError::ServerError { message },
+                _ => DockerError::Other {
+                    status_code: Some(status_code),
+                    message,
+                },
+            },
+            _ => DockerError::Other {
+                status_code: None,
+                message: err.to_string(),
+            },
+        }
+    }
+}
+
+impl From<bollard::secret::HealthStatusEnum> for ContainerHealthStatus {
+    fn from(status: bollard::secret::HealthStatusEnum) -> Self {
+        match status {
+            bollard::secret::HealthStatusEnum::EMPTY => ContainerHealthStatus::Empty,
+            bollard::secret::HealthStatusEnum::HEALTHY => ContainerHealthStatus::Healthy,
+            bollard::secret::HealthStatusEnum::UNHEALTHY => ContainerHealthStatus::Unhealthy,
+            bollard::secret::HealthStatusEnum::NONE => ContainerHealthStatus::None,
+            bollard::secret::HealthStatusEnum::STARTING => ContainerHealthStatus::Starting,
+        }
+    }
+}
+
 pub trait DockerInspectContainer {
     fn inspect_container(
         &self,
         container_id: &str,
         options: Option<InspectContainerOptions>,
-    ) -> impl Future<Output = Result<ContainerInspectResponse, Error>> + Send;
+    ) -> impl Future<Output = Result<ContainerInspectResponse, DockerError>> + Send;
 }
 
 impl DockerInspectContainer for Docker {
@@ -27,8 +90,10 @@ impl DockerInspectContainer for Docker {
         &self,
         container_id: &str,
         options: Option<InspectContainerOptions>,
-    ) -> Result<ContainerInspectResponse, Error> {
-        self.inspect_container(container_id, options).await
+    ) -> Result<ContainerInspectResponse, DockerError> {
+        self.inspect_container(container_id, options)
+            .await
+            .map_err(DockerError::from)
     }
 }
 
@@ -36,36 +101,39 @@ pub trait DockerListContainers {
     fn list_containers(
         &self,
         options: Option<ListContainersOptions>,
-    ) -> impl Future<Output = Result<Vec<ContainerSummary>, Error>> + Send;
+    ) -> impl Future<Output = Result<Vec<ContainerSummary>, DockerError>> + Send;
 }
 
 impl DockerListContainers for Docker {
     async fn list_containers(
         &self,
         options: Option<ListContainersOptions>,
-    ) -> Result<Vec<ContainerSummary>, Error> {
-        self.list_containers(options).await
+    ) -> Result<Vec<ContainerSummary>, DockerError> {
+        self.list_containers(options)
+            .await
+            .map_err(DockerError::from)
     }
 }
 
 pub trait DockerPullImage {
-    fn pull_image(&self, image: &str, tag: &str) -> impl Future<Output = Result<(), Error>> + Send;
+    fn pull_image(
+        &self,
+        image: &str,
+        tag: &str,
+    ) -> impl Future<Output = Result<(), DockerError>> + Send;
 }
 
 impl DockerPullImage for Docker {
-    async fn pull_image(&self, image: &str, tag: &str) -> Result<(), Error> {
-        // Build the options for pulling the Atlas Local Docker image
+    async fn pull_image(&self, image: &str, tag: &str) -> Result<(), DockerError> {
         let create_image_options = CreateImageOptionsBuilder::default()
             .from_image(image)
             .tag(tag)
             .build();
 
-        // Start pulling the image, which returns a stream of progress events
         let mut stream = self.create_image(Some(create_image_options), None, None);
 
-        // Iterate over the stream and check for errors
         while let Some(result) = stream.next().await {
-            result?;
+            result.map_err(DockerError::from)?;
         }
 
         Ok(())
@@ -77,7 +145,7 @@ pub trait DockerStopContainer {
         &self,
         container_id: &str,
         options: Option<StopContainerOptions>,
-    ) -> impl Future<Output = Result<(), Error>> + Send;
+    ) -> impl Future<Output = Result<(), DockerError>> + Send;
 }
 
 impl DockerStopContainer for Docker {
@@ -85,8 +153,10 @@ impl DockerStopContainer for Docker {
         &self,
         container_id: &str,
         options: Option<StopContainerOptions>,
-    ) -> Result<(), Error> {
-        self.stop_container(container_id, options).await
+    ) -> Result<(), DockerError> {
+        self.stop_container(container_id, options)
+            .await
+            .map_err(DockerError::from)
     }
 }
 
@@ -95,7 +165,7 @@ pub trait DockerRemoveContainer {
         &self,
         container_id: &str,
         options: Option<RemoveContainerOptions>,
-    ) -> impl Future<Output = Result<(), Error>> + Send;
+    ) -> impl Future<Output = Result<(), DockerError>> + Send;
 }
 
 impl DockerRemoveContainer for Docker {
@@ -103,8 +173,10 @@ impl DockerRemoveContainer for Docker {
         &self,
         container_id: &str,
         options: Option<RemoveContainerOptions>,
-    ) -> Result<(), Error> {
-        self.remove_container(container_id, options).await
+    ) -> Result<(), DockerError> {
+        self.remove_container(container_id, options)
+            .await
+            .map_err(DockerError::from)
     }
 }
 
@@ -113,7 +185,7 @@ pub trait DockerCreateContainer {
         &self,
         options: Option<CreateContainerOptions>,
         config: ContainerCreateBody,
-    ) -> impl Future<Output = Result<ContainerCreateResponse, Error>> + Send;
+    ) -> impl Future<Output = Result<ContainerCreateResponse, DockerError>> + Send;
 }
 
 impl DockerCreateContainer for Docker {
@@ -121,8 +193,10 @@ impl DockerCreateContainer for Docker {
         &self,
         options: Option<CreateContainerOptions>,
         config: ContainerCreateBody,
-    ) -> Result<ContainerCreateResponse, Error> {
-        self.create_container(options, config).await
+    ) -> Result<ContainerCreateResponse, DockerError> {
+        self.create_container(options, config)
+            .await
+            .map_err(DockerError::from)
     }
 }
 
@@ -131,7 +205,7 @@ pub trait DockerStartContainer {
         &self,
         container_id: &str,
         options: Option<StartContainerOptions>,
-    ) -> impl Future<Output = Result<(), Error>> + Send;
+    ) -> impl Future<Output = Result<(), DockerError>> + Send;
 }
 
 impl DockerStartContainer for Docker {
@@ -139,19 +213,25 @@ impl DockerStartContainer for Docker {
         &self,
         container_id: &str,
         options: Option<StartContainerOptions>,
-    ) -> Result<(), Error> {
-        self.start_container(container_id, options).await
+    ) -> Result<(), DockerError> {
+        self.start_container(container_id, options)
+            .await
+            .map_err(DockerError::from)
     }
 }
 
 pub trait DockerPauseContainer {
-    fn pause_container(&self, container_id: &str)
-    -> impl Future<Output = Result<(), Error>> + Send;
+    fn pause_container(
+        &self,
+        container_id: &str,
+    ) -> impl Future<Output = Result<(), DockerError>> + Send;
 }
 
 impl DockerPauseContainer for Docker {
-    async fn pause_container(&self, container_id: &str) -> Result<(), Error> {
-        self.pause_container(container_id).await
+    async fn pause_container(&self, container_id: &str) -> Result<(), DockerError> {
+        self.pause_container(container_id)
+            .await
+            .map_err(DockerError::from)
     }
 }
 
@@ -159,12 +239,14 @@ pub trait DockerUnpauseContainer {
     fn unpause_container(
         &self,
         container_id: &str,
-    ) -> impl Future<Output = Result<(), Error>> + Send;
+    ) -> impl Future<Output = Result<(), DockerError>> + Send;
 }
 
 impl DockerUnpauseContainer for Docker {
-    async fn unpause_container(&self, container_id: &str) -> Result<(), Error> {
-        self.unpause_container(container_id).await
+    async fn unpause_container(&self, container_id: &str) -> Result<(), DockerError> {
+        self.unpause_container(container_id)
+            .await
+            .map_err(DockerError::from)
     }
 }
 
@@ -184,13 +266,13 @@ pub struct CommandOutput {
 #[derive(Debug, thiserror::Error)]
 pub enum RunCommandInContainerError {
     #[error("Failed to create exec: {0}")]
-    CreateExec(Error),
+    CreateExec(DockerError),
     #[error("Failed to start exec: {0}")]
-    StartExec(Error),
+    StartExec(DockerError),
     #[error("Failed to get output, output was not attached")]
     GetOutput,
     #[error("Failed to get output: {0}")]
-    GetOutputError(Error),
+    GetOutputError(DockerError),
 }
 
 impl RunCommandInContainer for Docker {
@@ -210,7 +292,7 @@ impl RunCommandInContainer for Docker {
                 },
             )
             .await
-            .map_err(RunCommandInContainerError::CreateExec)?;
+            .map_err(|e| RunCommandInContainerError::CreateExec(DockerError::from(e)))?;
 
         let exec = self
             .start_exec(
@@ -222,7 +304,7 @@ impl RunCommandInContainer for Docker {
                 }),
             )
             .await
-            .map_err(RunCommandInContainerError::StartExec)?;
+            .map_err(|e| RunCommandInContainerError::StartExec(DockerError::from(e)))?;
 
         let StartExecResults::Attached { mut output, .. } = exec else {
             return Err(RunCommandInContainerError::GetOutput);
@@ -232,7 +314,8 @@ impl RunCommandInContainer for Docker {
         let mut stderr = String::new();
 
         while let Some(result) = output.next().await {
-            let log_ouput = result.map_err(RunCommandInContainerError::GetOutputError)?;
+            let log_ouput = result
+                .map_err(|e| RunCommandInContainerError::GetOutputError(DockerError::from(e)))?;
 
             match log_ouput {
                 LogOutput::StdOut { message } => {

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -17,20 +17,20 @@ use crate::models::ContainerHealthStatus;
 
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum DockerError {
-    #[error("resource not modified: {message}")]
-    NotModified { message: String },
-    #[error("bad request: {message}")]
-    BadRequest { message: String },
-    #[error("unauthorized: {message}")]
-    Unauthorized { message: String },
-    #[error("forbidden: {message}")]
-    Forbidden { message: String },
-    #[error("not found: {message}")]
-    NotFound { message: String },
-    #[error("conflict: {message}")]
-    Conflict { message: String },
-    #[error("internal server error: {message}")]
-    ServerError { message: String },
+    #[error("resource not modified")]
+    NotModified,
+    #[error("bad request")]
+    BadRequest,
+    #[error("unauthorized")]
+    Unauthorized,
+    #[error("forbidden")]
+    Forbidden,
+    #[error("not found")]
+    NotFound,
+    #[error("conflict")]
+    Conflict,
+    #[error("internal server error")]
+    ServerError,
     #[error("docker error (status {status_code:?}): {message}")]
     Other {
         status_code: Option<u16>,
@@ -41,22 +41,21 @@ pub enum DockerError {
 impl From<bollard::errors::Error> for DockerError {
     fn from(err: bollard::errors::Error) -> Self {
         match err {
-            bollard::errors::Error::DockerResponseServerError {
-                status_code,
-                message,
-            } => match status_code {
-                304 => DockerError::NotModified { message },
-                400 => DockerError::BadRequest { message },
-                401 => DockerError::Unauthorized { message },
-                403 => DockerError::Forbidden { message },
-                404 => DockerError::NotFound { message },
-                409 => DockerError::Conflict { message },
-                500 => DockerError::ServerError { message },
-                _ => DockerError::Other {
-                    status_code: Some(status_code),
-                    message,
-                },
-            },
+            bollard::errors::Error::DockerResponseServerError { status_code, message } => {
+                match status_code {
+                    304 => DockerError::NotModified,
+                    400 => DockerError::BadRequest,
+                    401 => DockerError::Unauthorized,
+                    403 => DockerError::Forbidden,
+                    404 => DockerError::NotFound,
+                    409 => DockerError::Conflict,
+                    500 => DockerError::ServerError,
+                    _ => DockerError::Other {
+                        status_code: Some(status_code),
+                        message,
+                    },
+                }
+            }
             _ => DockerError::Other {
                 status_code: None,
                 message: err.to_string(),

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -335,6 +335,164 @@ impl RunCommandInContainer for Docker {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_docker_error_from_bollard_not_modified() {
+        let err = bollard::errors::Error::DockerResponseServerError {
+            status_code: 304,
+            message: "Not Modified".to_string(),
+        };
+        assert_eq!(DockerError::from(err), DockerError::NotModified);
+    }
+
+    #[test]
+    fn test_docker_error_from_bollard_bad_request() {
+        let err = bollard::errors::Error::DockerResponseServerError {
+            status_code: 400,
+            message: "Bad Request".to_string(),
+        };
+        assert_eq!(DockerError::from(err), DockerError::BadRequest);
+    }
+
+    #[test]
+    fn test_docker_error_from_bollard_unauthorized() {
+        let err = bollard::errors::Error::DockerResponseServerError {
+            status_code: 401,
+            message: "Unauthorized".to_string(),
+        };
+        assert_eq!(DockerError::from(err), DockerError::Unauthorized);
+    }
+
+    #[test]
+    fn test_docker_error_from_bollard_forbidden() {
+        let err = bollard::errors::Error::DockerResponseServerError {
+            status_code: 403,
+            message: "Forbidden".to_string(),
+        };
+        assert_eq!(DockerError::from(err), DockerError::Forbidden);
+    }
+
+    #[test]
+    fn test_docker_error_from_bollard_not_found() {
+        let err = bollard::errors::Error::DockerResponseServerError {
+            status_code: 404,
+            message: "Not Found".to_string(),
+        };
+        assert_eq!(DockerError::from(err), DockerError::NotFound);
+    }
+
+    #[test]
+    fn test_docker_error_from_bollard_conflict() {
+        let err = bollard::errors::Error::DockerResponseServerError {
+            status_code: 409,
+            message: "Conflict".to_string(),
+        };
+        assert_eq!(DockerError::from(err), DockerError::Conflict);
+    }
+
+    #[test]
+    fn test_docker_error_from_bollard_server_error() {
+        let err = bollard::errors::Error::DockerResponseServerError {
+            status_code: 500,
+            message: "Internal Server Error".to_string(),
+        };
+        assert_eq!(DockerError::from(err), DockerError::ServerError);
+    }
+
+    #[test]
+    fn test_docker_error_from_bollard_other_status_code() {
+        let err = bollard::errors::Error::DockerResponseServerError {
+            status_code: 503,
+            message: "Service Unavailable".to_string(),
+        };
+        assert_eq!(
+            DockerError::from(err),
+            DockerError::Other {
+                status_code: Some(503),
+                message: "Service Unavailable".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_docker_error_from_bollard_non_server_error() {
+        let err = bollard::errors::Error::RequestTimeoutError;
+        let result = DockerError::from(err);
+        assert!(matches!(
+            result,
+            DockerError::Other {
+                status_code: None,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_docker_error_display() {
+        assert_eq!(DockerError::NotModified.to_string(), "resource not modified");
+        assert_eq!(DockerError::BadRequest.to_string(), "bad request");
+        assert_eq!(DockerError::Unauthorized.to_string(), "unauthorized");
+        assert_eq!(DockerError::Forbidden.to_string(), "forbidden");
+        assert_eq!(DockerError::NotFound.to_string(), "not found");
+        assert_eq!(DockerError::Conflict.to_string(), "conflict");
+        assert_eq!(
+            DockerError::ServerError.to_string(),
+            "internal server error"
+        );
+        assert_eq!(
+            DockerError::Other {
+                status_code: Some(503),
+                message: "oops".to_string(),
+            }
+            .to_string(),
+            "docker error (status Some(503)): oops"
+        );
+    }
+
+    #[test]
+    fn test_container_health_status_from_bollard_empty() {
+        assert_eq!(
+            ContainerHealthStatus::from(bollard::secret::HealthStatusEnum::EMPTY),
+            ContainerHealthStatus::Empty
+        );
+    }
+
+    #[test]
+    fn test_container_health_status_from_bollard_healthy() {
+        assert_eq!(
+            ContainerHealthStatus::from(bollard::secret::HealthStatusEnum::HEALTHY),
+            ContainerHealthStatus::Healthy
+        );
+    }
+
+    #[test]
+    fn test_container_health_status_from_bollard_unhealthy() {
+        assert_eq!(
+            ContainerHealthStatus::from(bollard::secret::HealthStatusEnum::UNHEALTHY),
+            ContainerHealthStatus::Unhealthy
+        );
+    }
+
+    #[test]
+    fn test_container_health_status_from_bollard_none() {
+        assert_eq!(
+            ContainerHealthStatus::from(bollard::secret::HealthStatusEnum::NONE),
+            ContainerHealthStatus::None
+        );
+    }
+
+    #[test]
+    fn test_container_health_status_from_bollard_starting() {
+        assert_eq!(
+            ContainerHealthStatus::from(bollard::secret::HealthStatusEnum::STARTING),
+            ContainerHealthStatus::Starting
+        );
+    }
+}
+
 pub trait DockerLogContainer {
     fn logs<'a>(
         &'a self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,3 +15,5 @@ pub use client::{
     Client, CreateDeploymentError, DeleteDeploymentError, GetConnectionStringError,
     GetDeploymentError, GetDeploymentIdError, GetLogsError, PullImageError,
 };
+pub use docker::DockerError;
+pub use models::ContainerHealthStatus;

--- a/src/models/container_health_status.rs
+++ b/src/models/container_health_status.rs
@@ -20,3 +20,17 @@ impl fmt::Display for ContainerHealthStatus {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_display() {
+        assert_eq!(ContainerHealthStatus::Empty.to_string(), "empty");
+        assert_eq!(ContainerHealthStatus::Healthy.to_string(), "healthy");
+        assert_eq!(ContainerHealthStatus::Unhealthy.to_string(), "unhealthy");
+        assert_eq!(ContainerHealthStatus::None.to_string(), "none");
+        assert_eq!(ContainerHealthStatus::Starting.to_string(), "starting");
+    }
+}

--- a/src/models/container_health_status.rs
+++ b/src/models/container_health_status.rs
@@ -1,0 +1,22 @@
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ContainerHealthStatus {
+    Empty,
+    Healthy,
+    Unhealthy,
+    None,
+    Starting,
+}
+
+impl fmt::Display for ContainerHealthStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ContainerHealthStatus::Empty => write!(f, "empty"),
+            ContainerHealthStatus::Healthy => write!(f, "healthy"),
+            ContainerHealthStatus::Unhealthy => write!(f, "unhealthy"),
+            ContainerHealthStatus::None => write!(f, "none"),
+            ContainerHealthStatus::Starting => write!(f, "starting"),
+        }
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,3 +1,4 @@
+mod container_health_status;
 mod create_deployment_options;
 mod creation_source;
 mod deployment;
@@ -12,6 +13,7 @@ mod port_binding;
 mod state;
 mod watch_options;
 
+pub use container_health_status::*;
 pub use create_deployment_options::*;
 pub use creation_source::*;
 pub use deployment::*;


### PR DESCRIPTION
## Summary

- Introduces `DockerError` enum (in `src/docker.rs`) to replace `bollard::errors::Error` in all public-facing error types and docker trait signatures. Named variants per Docker API HTTP codes: `NotModified`, `BadRequest`, `Unauthorized`, `Forbidden`, `NotFound`, `Conflict`, `ServerError`, `Other { status_code: Option<u16> }`.
- Introduces `ContainerHealthStatus` enum (in `src/models/container_health_status.rs`) to replace `bollard::secret::HealthStatusEnum` in `WatchDeploymentError`. 1:1 mapping with bollard's enum.
- `From` conversions for both types are contained in `docker.rs` — bollard is no longer visible anywhere in the public API.
- Both types re-exported from crate root.

Closes CLOUDP-372198

## Test Plan

- [x] All 196 unit tests pass (`cargo test`)
- [x] No `bollard::errors::Error` or `bollard::secret::HealthStatusEnum` in any public type outside `docker.rs`