### PR TITLE
feat: add bollard feature with re-export and Client convenience constructors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,10 @@ include = [
 ]
 
 [features]
-default = ["serde"]
+default = ["serde", "bollard"]
 e2e-tests = []
 serde = ["dep:serde", "semver/serde"]
+bollard = []
 
 [dependencies]
 bollard = "0.21.0"

--- a/examples/container_lifecycle.rs
+++ b/examples/container_lifecycle.rs
@@ -3,12 +3,10 @@ use atlas_local::{
     Client,
     models::{CreateDeploymentOptions, Deployment},
 };
-use bollard::Docker;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let docker = Docker::connect_with_socket_defaults().context("connecting to docker")?;
-    let client = Client::new(docker);
+    let client = Client::connect_with_socket_defaults().context("connecting to docker")?;
 
     // Create a deployment for demonstration
     let deployment_name = "lifecycle-demo";

--- a/examples/create_deployment.rs
+++ b/examples/create_deployment.rs
@@ -1,11 +1,9 @@
 use anyhow::{Context, Result};
 use atlas_local::{Client, models::CreateDeploymentOptions};
-use bollard::Docker;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let docker = Docker::connect_with_defaults().context("connecting to docker")?;
-    let client = Client::new(docker);
+    let client = Client::connect_with_defaults().context("connecting to docker")?;
 
     // Create a deployment with the name local1234 and loaded sample data
     // More details about sample data can be found here: https://docs.mongodb.com/atlas/sample-data/

--- a/examples/create_deployment_with_progress.rs
+++ b/examples/create_deployment_with_progress.rs
@@ -2,13 +2,11 @@ use std::io::{self, Write};
 
 use anyhow::{Context, Result};
 use atlas_local::{Client, client::CreateDeploymentStepOutcome};
-use bollard::Docker;
 use tokio::sync::oneshot::error::RecvError;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let docker = Docker::connect_with_defaults().context("connecting to docker")?;
-    let client = Client::new(docker);
+    let client = Client::connect_with_defaults().context("connecting to docker")?;
 
     // Create a deployment with an automatically generated name, and default settings
     // More details about sample data can be found here: https://docs.mongodb.com/atlas/sample-data/

--- a/examples/delete_deployments.rs
+++ b/examples/delete_deployments.rs
@@ -1,11 +1,9 @@
 use anyhow::{Context, Result};
 use atlas_local::Client;
-use bollard::Docker;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let docker = Docker::connect_with_socket_defaults().context("connecting to docker")?;
-    let client = Client::new(docker);
+    let client = Client::connect_with_socket_defaults().context("connecting to docker")?;
 
     client
         .delete_deployment("local1234")

--- a/examples/get_connection_string.rs
+++ b/examples/get_connection_string.rs
@@ -1,11 +1,9 @@
 use anyhow::{Context, Result};
 use atlas_local::Client;
-use bollard::Docker;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let docker = Docker::connect_with_defaults().context("connecting to docker")?;
-    let client = Client::new(docker.clone());
+    let client = Client::connect_with_defaults().context("connecting to docker")?;
 
     let deployments = client
         .list_deployments()

--- a/examples/get_deployment_id.rs
+++ b/examples/get_deployment_id.rs
@@ -1,11 +1,9 @@
 use anyhow::{Context, Result};
 use atlas_local::{Client, models::CreateDeploymentOptions};
-use bollard::Docker;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let docker = Docker::connect_with_defaults().context("connecting to docker")?;
-    let client = Client::new(docker.clone());
+    let client = Client::connect_with_defaults().context("connecting to docker")?;
 
     let deployment_options = CreateDeploymentOptions::default();
     let deployment = client

--- a/examples/get_logs.rs
+++ b/examples/get_logs.rs
@@ -3,12 +3,10 @@ use atlas_local::{
     Client,
     models::{CreateDeploymentOptions, LogsOptions, Tail},
 };
-use bollard::Docker;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let docker = Docker::connect_with_defaults().context("connecting to docker")?;
-    let client = Client::new(docker.clone());
+    let client = Client::connect_with_defaults().context("connecting to docker")?;
 
     let deployment_options = CreateDeploymentOptions::default();
     let deployment = client

--- a/examples/list_deployments.rs
+++ b/examples/list_deployments.rs
@@ -1,11 +1,9 @@
 use anyhow::{Context, Result};
 use atlas_local::Client;
-use bollard::Docker;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let docker = Docker::connect_with_socket_defaults().context("connecting to docker")?;
-    let client = Client::new(docker);
+    let client = Client::connect_with_socket_defaults().context("connecting to docker")?;
 
     let deployments = client
         .list_deployments()

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -67,6 +67,23 @@ impl<D> Client<D> {
     }
 }
 
+#[cfg(feature = "bollard")]
+impl Client<bollard::Docker> {
+    /// Creates a new client by connecting to Docker using the default connection method.
+    ///
+    /// Equivalent to calling `Client::new(Docker::connect_with_defaults()?)`.
+    pub fn connect_with_defaults() -> Result<Self, bollard::errors::Error> {
+        Ok(Client::new(bollard::Docker::connect_with_defaults()?))
+    }
+
+    /// Creates a new client by connecting to Docker via the default Unix socket.
+    ///
+    /// Equivalent to calling `Client::new(Docker::connect_with_socket_defaults()?)`.
+    pub fn connect_with_socket_defaults() -> Result<Self, bollard::errors::Error> {
+        Ok(Client::new(bollard::Docker::connect_with_socket_defaults()?))
+    }
+}
+
 impl<D> Clone for Client<D> {
     fn clone(&self) -> Self {
         Client {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,9 @@ pub mod models;
 #[cfg(test)]
 pub mod test_utils;
 
+#[cfg(feature = "bollard")]
+pub use bollard;
+
 // Re-export the main types for convenience
 pub use client::{
     Client, CreateDeploymentError, DeleteDeploymentError, GetConnectionStringError,


### PR DESCRIPTION
## Summary

- Adds a `bollard` feature (enabled by default) that re-exports the bollard crate as `atlas_local::bollard`
- Adds `Client::connect_with_defaults()` and `Client::connect_with_socket_defaults()` convenience constructors so users don't need to import bollard directly
- Updates all examples to use the new constructors

## Usage

Before:
```rust
use bollard::Docker;
use atlas_local::Client;

let docker = Docker::connect_with_defaults()?;
let client = Client::new(docker);
```

After:
```rust
use atlas_local::Client;

let client = Client::connect_with_defaults()?;
```

Or, if users want bollard directly via the re-export:
```rust
use atlas_local::bollard::Docker;
```

## Notes

- Pre-existing clippy errors exist on `main` (unwrap/panic in test code) — not introduced by this PR
- Disabling the feature (`default-features = false`) still compiles; it just omits the re-export and convenience constructors

## Jira
Related JIRA: [CLOUDP-372198](https://jira.mongodb.org/browse/CLOUDP-372198)