### PR TITLE
chore: add Jira automation workflows

### DIFF
--- a/.github/workflows/close-jira.yaml
+++ b/.github/workflows/close-jira.yaml
@@ -1,0 +1,17 @@
+# sync -> mongodb/atlas-local-lib
+# sync -> mongodb/atlas-local-cli
+# sync -> mongodb-js/atlas-local-lib-js
+
+name: Auto Close Jira
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions: {}
+
+jobs:
+  close-jira:
+    if: contains(github.event.pull_request.labels.*.name, 'auto_close_jira')
+    uses: mongodb/apix-action/.github/workflows/_close-jira.yaml@main
+    secrets: inherit

--- a/.github/workflows/create-jira.yaml
+++ b/.github/workflows/create-jira.yaml
@@ -1,0 +1,20 @@
+# sync -> mongodb/atlas-local-lib
+# sync -> mongodb/atlas-local-cli
+# sync -> mongodb-js/atlas-local-lib-js
+# sync -> mongodb/mongodb-atlas-cli
+# sync -> mongodb/mongodb-atlas-local
+# sync -> mongodb-labs/cobra2snooty
+
+name: Create Jira Ticket
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions: {}
+
+jobs:
+  create-jira:
+    if: github.event.label.name == 'create_jira'
+    uses: mongodb/apix-action/.github/workflows/_create-jira.yaml@main
+    secrets: inherit

--- a/.github/workflows/dependabot-jira.yaml
+++ b/.github/workflows/dependabot-jira.yaml
@@ -1,0 +1,17 @@
+# sync -> mongodb/atlas-local-lib
+# sync -> mongodb/atlas-local-cli
+# sync -> mongodb-js/atlas-local-lib-js
+
+name: Create Jira Ticket for Dependabot PRs
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  create-jira:
+    if: github.actor == 'dependabot[bot]'
+    uses: mongodb/apix-action/.github/workflows/_dependabot-jira.yaml@main
+    secrets: inherit

--- a/.github/workflows/issue-closed.yaml
+++ b/.github/workflows/issue-closed.yaml
@@ -1,0 +1,18 @@
+# sync -> mongodb/mongodb-atlas-local
+# sync -> mongodb/atlas-local-lib
+# sync -> mongodb/atlas-local-cli
+# sync -> mongodb-js/atlas-local-lib-js
+# sync -> mongodb-labs/cobra2snooty
+
+name: Close Jira Ticket on Issue Close
+
+on:
+  issues:
+    types: [closed]
+
+permissions: {}
+
+jobs:
+  close-jira:
+    uses: mongodb/apix-action/.github/workflows/_issue-closed.yaml@main
+    secrets: inherit

--- a/.github/workflows/issue-opened.yaml
+++ b/.github/workflows/issue-opened.yaml
@@ -1,0 +1,18 @@
+# sync -> mongodb/mongodb-atlas-local
+# sync -> mongodb/atlas-local-lib
+# sync -> mongodb/atlas-local-cli
+# sync -> mongodb-js/atlas-local-lib-js
+# sync -> mongodb-labs/cobra2snooty
+
+name: Create Jira Ticket for New Issues
+
+on:
+  issues:
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  create-jira:
+    uses: mongodb/apix-action/.github/workflows/_issue-opened.yaml@main
+    secrets: inherit

--- a/.github/workflows/issue-reopened.yaml
+++ b/.github/workflows/issue-reopened.yaml
@@ -1,0 +1,18 @@
+# sync -> mongodb/mongodb-atlas-local
+# sync -> mongodb/atlas-local-lib
+# sync -> mongodb/atlas-local-cli
+# sync -> mongodb-js/atlas-local-lib-js
+# sync -> mongodb-labs/cobra2snooty
+
+name: Reopen Jira Ticket on Issue Reopen
+
+on:
+  issues:
+    types: [reopened]
+
+permissions: {}
+
+jobs:
+  reopen-jira:
+    uses: mongodb/apix-action/.github/workflows/_issue-reopened.yaml@main
+    secrets: inherit


### PR DESCRIPTION
Followup from mongodb/apix-action#123.

## Summary

Adds the Jira automation workflows, now hosted and versioned in [`mongodb/apix-action`](https://github.com/mongodb/apix-action):

| Workflow | Trigger | Description |
|---|---|---|
| `close-jira.yaml` | PR closed with `auto_close_jira` label | Transitions the linked CLOUDP ticket to Fixed or Won't Fix |
| `create-jira.yaml` | PR labeled with `create_jira` | Creates a CLOUDP Story and links it in a PR comment |
| `dependabot-jira.yaml` | PR opened by Dependabot | Creates a CLOUDP Story for Dependabot PRs |
| `issue-closed.yaml` | Issue closed | Closes the linked CLOUDP ticket |
| `issue-opened.yaml` | Issue opened | Creates a CLOUDP Story and comments on the issue |
| `issue-reopened.yaml` | Issue reopened | Reopens the linked CLOUDP ticket |

## Note

The reusable workflow logic lives in `mongodb/apix-action` and is referenced from these callers. No secrets beyond `OP_SERVICE_ACCOUNT_TOKEN` are needed in this repo — all credentials are loaded from 1Password at runtime.

## Test plan

- [ ] Add `create_jira` label to a test PR and verify a CLOUDP ticket is created and linked
- [ ] Close the PR and verify the ticket transitions correctly
- [ ] Open a test issue and verify a CLOUDP ticket is created