### PR TITLE
chore(CI): Fixes coverall failing to install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,16 +137,20 @@ jobs:
     - name: Generate coverage report
       run: cargo llvm-cov --lib --verbose --lcov --output-path=unit-tests.lcov
     
+    # Recent Homebrew refuses to load formulae from non-official taps unless
+    # they are explicitly trusted. The coverallsapp/github-action installs its
+    # reporter via `brew install coverallsapp/coveralls/coveralls`, which fails
+    # on macOS with "Refusing to load formula ... from untrusted tap". Tap and
+    # trust it here so the action's install step succeeds.
+    - name: Trust coveralls Homebrew tap (macOS)
+      if: runner.os == 'macOS'
+      run: |
+        brew tap coverallsapp/coveralls
+        brew trust --tap coverallsapp/coveralls
+
     - name: Upload coverage report
-      # continue-on-error: coverage upload is non-critical; a Coveralls/network
-      # failure should not fail the build (all tests already ran).
-      continue-on-error: true
       env:
         COVERALLS_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        # Force Homebrew to install the coveralls formula from a local tap clone
-        # instead of the API. Without this, recent Homebrew refuses the
-        # coverallsapp/coveralls tap as "untrusted" and the macOS job fails.
-        HOMEBREW_NO_INSTALL_FROM_API: "1"
       uses: coverallsapp/github-action@v2.3.6
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -220,7 +224,6 @@ jobs:
         run: cargo llvm-cov --test '*' --workspace --exclude 'src/*' --verbose --features e2e-tests --lcov --output-path=e2e-tests.lcov
 
       - name: Upload coverage report
-        continue-on-error: true
         uses: coverallsapp/github-action@v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -234,7 +237,6 @@ jobs:
     needs: [test-matrix, e2e-tests]
     steps:
       - name: Send coverage
-        continue-on-error: true
         env:
           COVERALLS_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         uses: coverallsapp/github-action@v2.3.6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,8 +138,15 @@ jobs:
       run: cargo llvm-cov --lib --verbose --lcov --output-path=unit-tests.lcov
     
     - name: Upload coverage report
+      # continue-on-error: coverage upload is non-critical; a Coveralls/network
+      # failure should not fail the build (all tests already ran).
+      continue-on-error: true
       env:
         COVERALLS_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        # Force Homebrew to install the coveralls formula from a local tap clone
+        # instead of the API. Without this, recent Homebrew refuses the
+        # coverallsapp/coveralls tap as "untrusted" and the macOS job fails.
+        HOMEBREW_NO_INSTALL_FROM_API: "1"
       uses: coverallsapp/github-action@v2.3.6
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -213,6 +220,7 @@ jobs:
         run: cargo llvm-cov --test '*' --workspace --exclude 'src/*' --verbose --features e2e-tests --lcov --output-path=e2e-tests.lcov
 
       - name: Upload coverage report
+        continue-on-error: true
         uses: coverallsapp/github-action@v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -226,6 +234,7 @@ jobs:
     needs: [test-matrix, e2e-tests]
     steps:
       - name: Send coverage
+        continue-on-error: true
         env:
           COVERALLS_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         uses: coverallsapp/github-action@v2.3.6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,11 +137,8 @@ jobs:
     - name: Generate coverage report
       run: cargo llvm-cov --lib --verbose --lcov --output-path=unit-tests.lcov
     
-    # Recent Homebrew refuses to load formulae from non-official taps unless
-    # they are explicitly trusted. The coverallsapp/github-action installs its
-    # reporter via `brew install coverallsapp/coveralls/coveralls`, which fails
-    # on macOS with "Refusing to load formula ... from untrusted tap". Tap and
-    # trust it here so the action's install step succeeds.
+    # Homebrew will refuse to load formulae from non-official taps unless
+    # they are explicitly trusted.
     - name: Trust coveralls Homebrew tap (macOS)
       if: runner.os == 'macOS'
       run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "atlas-local"

--- a/LICENSE-3RD-PARTY.txt
+++ b/LICENSE-3RD-PARTY.txt
@@ -3419,7 +3419,7 @@ limitations under the License.
                         Apache License 2.0
         applies to: 
         - android_system_properties 0.1.5 (https://github.com/nical/android_system_properties)
-        - anyhow 1.0.102 (https://github.com/dtolnay/anyhow)
+        - anyhow 1.0.103 (https://github.com/dtolnay/anyhow)
         - bollard-stubs 1.53.1-rc.29.3.1 (https://crates.io/crates/bollard-stubs)
         - itoa 1.0.15 (https://github.com/dtolnay/itoa)
         - libc 0.2.175 (https://github.com/rust-lang/libc)


### PR DESCRIPTION
All PRs have bee failing on `CI / test-matrix (macos-latest, stable)`  as new homebrew version refuses to load formulae from non-official taps unless they are explicitly trusted. The coverallsapp/github-action installs its reporter via `brew install coverallsapp/coveralls/coveralls`, which fails on macOS with `Refusing to load formula ... from untrusted tap`. 

Fixes this by tapping and trusting coveralls prior to installation