### PR TITLE
feat!: start_deployment waits for the deployment to become healthy by default

### DIFF
--- a/examples/container_lifecycle.rs
+++ b/examples/container_lifecycle.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use atlas_local::{
     Client,
-    models::{CreateDeploymentOptions, Deployment},
+    models::{CreateDeploymentOptions, Deployment, StartDeploymentOptions},
 };
 
 #[tokio::main]
@@ -33,7 +33,7 @@ async fn main() -> Result<()> {
     // Start the deployment
     println!("Starting deployment '{}'...", deployment_name);
     client
-        .start_deployment(deployment_name)
+        .start_deployment(deployment_name, StartDeploymentOptions::default())
         .await
         .context("starting deployment")?;
 

--- a/src/client/start_deployment.rs
+++ b/src/client/start_deployment.rs
@@ -3,9 +3,10 @@ use bollard::query_parameters::StartContainerOptions;
 use crate::{
     client::Client,
     docker::{DockerInspectContainer, DockerStartContainer},
+    models::{StartDeploymentOptions, WatchOptions},
 };
 
-use super::GetDeploymentError;
+use super::{GetDeploymentError, WatchDeploymentError};
 
 #[derive(Debug, thiserror::Error)]
 pub enum StartDeploymentError {
@@ -13,11 +14,21 @@ pub enum StartDeploymentError {
     ContainerStart(String),
     #[error("Failed to get deployment: {0}")]
     GetDeployment(#[from] GetDeploymentError),
+    #[error("Error when waiting for deployment to become healthy: {0}")]
+    WatchDeployment(#[from] WatchDeploymentError),
 }
 
 impl<D: DockerStartContainer + DockerInspectContainer> Client<D> {
     /// Starts a local Atlas deployment.
-    pub async fn start_deployment(&self, name: &str) -> Result<(), StartDeploymentError> {
+    ///
+    /// By default this waits for the deployment to become healthy before
+    /// returning. Set [`StartDeploymentOptions::wait_until_healthy`] to `false`
+    /// to return as soon as the container has been started.
+    pub async fn start_deployment(
+        &self,
+        name: &str,
+        options: StartDeploymentOptions,
+    ) -> Result<(), StartDeploymentError> {
         // Check that a deployment with that name exists and get the container ID.
         // This ensures we only try to start valid Atlas local deployments.
         let deployment = self.get_deployment(name).await?;
@@ -29,6 +40,17 @@ impl<D: DockerStartContainer + DockerInspectContainer> Client<D> {
             .await
             .map_err(|e| StartDeploymentError::ContainerStart(e.to_string()))?;
 
+        // Default to waiting for the deployment to be healthy, so that is
+        // ready to accept connections when this returns.
+        if options.wait_until_healthy.unwrap_or(true) {
+            let watch_options = WatchOptions {
+                timeout_duration: options.wait_until_healthy_timeout,
+                allow_unhealthy_initial_state: true,
+            };
+            self.wait_for_healthy_deployment(name, watch_options)
+                .await?;
+        }
+
         Ok(())
     }
 }
@@ -36,8 +58,11 @@ impl<D: DockerStartContainer + DockerInspectContainer> Client<D> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::docker::DockerError;
-    use bollard::{models::ContainerInspectResponse, query_parameters::InspectContainerOptions};
+    use crate::{docker::DockerError, models::ContainerHealthStatus};
+    use bollard::{
+        models::{ContainerInspectResponse, Health, HealthStatusEnum},
+        query_parameters::InspectContainerOptions,
+    };
     use mockall::mock;
 
     mock! {
@@ -60,7 +85,13 @@ mod tests {
         }
     }
 
-    fn create_test_container_inspect_response() -> ContainerInspectResponse {
+    fn create_healthy_test_container_inspect_response() -> ContainerInspectResponse {
+        create_test_container_inspect_response_with_health(Some(HealthStatusEnum::HEALTHY))
+    }
+
+    fn create_test_container_inspect_response_with_health(
+        health: Option<HealthStatusEnum>,
+    ) -> ContainerInspectResponse {
         use bollard::models::{ContainerConfig, ContainerState, ContainerStateStatusEnum};
         use std::collections::HashMap;
 
@@ -81,6 +112,10 @@ mod tests {
             }),
             state: Some(ContainerState {
                 status: Some(ContainerStateStatusEnum::RUNNING),
+                health: health.map(|status| Health {
+                    status: Some(status),
+                    ..Default::default()
+                }),
                 ..Default::default()
             }),
             ..Default::default()
@@ -88,7 +123,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_start_deployment() {
+    async fn test_start_deployment_waits_until_healthy() {
         // Arrange
         let mut mock_docker = MockDocker::new();
 
@@ -99,8 +134,8 @@ mod tests {
                 mockall::predicate::eq("test-deployment"),
                 mockall::predicate::eq(None::<InspectContainerOptions>),
             )
-            .times(1)
-            .returning(move |_, _| Ok(create_test_container_inspect_response()));
+            .times(2)
+            .returning(move |_, _| Ok(create_healthy_test_container_inspect_response()));
 
         mock_docker
             .expect_start_container()
@@ -114,7 +149,201 @@ mod tests {
         let client = Client::new(mock_docker);
 
         // Act
-        let result = client.start_deployment("test-deployment").await;
+        let result = client
+            .start_deployment("test-deployment", StartDeploymentOptions::default())
+            .await;
+
+        // Assert
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_start_deployment_waits_while_starting() {
+        // Arrange
+        let mut mock_docker = MockDocker::new();
+        let mut calls = 0;
+
+        mock_docker
+            .expect_inspect_container()
+            .times(3)
+            .returning(move |_, _| {
+                calls += 1;
+                // First call resolves the deployment, then STARTING, then HEALTHY.
+                Ok(match calls {
+                    2 => create_test_container_inspect_response_with_health(Some(
+                        HealthStatusEnum::STARTING,
+                    )),
+                    _ => create_healthy_test_container_inspect_response(),
+                })
+            });
+
+        mock_docker
+            .expect_start_container()
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        let client = Client::new(mock_docker);
+
+        // Act
+        let result = client
+            .start_deployment("test-deployment", StartDeploymentOptions::default())
+            .await;
+
+        // Assert
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_start_deployment_unhealthy_initial_state_is_allowed() {
+        // Arrange
+        let mut mock_docker = MockDocker::new();
+        let mut calls = 0;
+
+        // Set up expectations
+        mock_docker
+            .expect_inspect_container()
+            .times(3)
+            .returning(move |_, _| {
+                calls += 1;
+                Ok(match calls {
+                    2 => create_test_container_inspect_response_with_health(Some(
+                        HealthStatusEnum::UNHEALTHY,
+                    )),
+                    _ => create_healthy_test_container_inspect_response(),
+                })
+            });
+
+        mock_docker
+            .expect_start_container()
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        let client = Client::new(mock_docker);
+
+        // Act
+        let result = client
+            .start_deployment("test-deployment", StartDeploymentOptions::default())
+            .await;
+
+        // Assert
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_start_deployment_unhealthy_times_out() {
+        // Arrange
+        let mut mock_docker = MockDocker::new();
+        let options = StartDeploymentOptions::builder()
+            .wait_until_healthy_timeout(std::time::Duration::from_millis(50))
+            .build();
+
+        // Set up expectations
+        mock_docker
+            .expect_inspect_container()
+            .times(2)
+            .returning(|_, _| {
+                Ok(create_test_container_inspect_response_with_health(Some(
+                    HealthStatusEnum::UNHEALTHY,
+                )))
+            });
+
+        mock_docker
+            .expect_start_container()
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        let client = Client::new(mock_docker);
+
+        // Act
+        let result = client.start_deployment("test-deployment", options).await;
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(StartDeploymentError::WatchDeployment(
+                WatchDeploymentError::Timeout { .. }
+            ))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_start_deployment_watch_error() {
+        // Arrange
+        let mut mock_docker = MockDocker::new();
+        let mut calls = 0;
+
+        mock_docker
+            .expect_inspect_container()
+            .times(2)
+            .returning(move |_, _| {
+                calls += 1;
+                // The health check finds no health information at all.
+                Ok(if calls == 1 {
+                    create_healthy_test_container_inspect_response()
+                } else {
+                    create_test_container_inspect_response_with_health(None)
+                })
+            });
+
+        mock_docker
+            .expect_start_container()
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        let client = Client::new(mock_docker);
+
+        // Act
+        let result = client
+            .start_deployment("test-deployment", StartDeploymentOptions::default())
+            .await;
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(StartDeploymentError::WatchDeployment(
+                WatchDeploymentError::UnhealthyDeployment {
+                    status: ContainerHealthStatus::None,
+                    ..
+                }
+            ))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_start_deployment_without_waiting() {
+        // Arrange
+        let mut mock_docker = MockDocker::new();
+
+        // Set up expectations
+        mock_docker
+            .expect_inspect_container()
+            .with(
+                mockall::predicate::eq("test-deployment"),
+                mockall::predicate::eq(None::<InspectContainerOptions>),
+            )
+            .times(1)
+            .returning(move |_, _| Ok(create_healthy_test_container_inspect_response()));
+
+        mock_docker
+            .expect_start_container()
+            .with(
+                mockall::predicate::eq("test_container_id"),
+                mockall::predicate::eq(None::<StartContainerOptions>),
+            )
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        let client = Client::new(mock_docker);
+
+        // Act
+        let result = client
+            .start_deployment(
+                "test-deployment",
+                StartDeploymentOptions::builder()
+                    .wait_until_healthy(false)
+                    .build(),
+            )
+            .await;
 
         // Assert
         assert!(result.is_ok());
@@ -134,13 +363,16 @@ mod tests {
         let client = Client::new(mock_docker);
 
         // Act
-        let result = client.start_deployment("nonexistent-deployment").await;
+        let result = client
+            .start_deployment("nonexistent-deployment", StartDeploymentOptions::default())
+            .await;
 
         // Assert
-        assert!(result.is_err());
         assert!(matches!(
-            result.unwrap_err(),
-            StartDeploymentError::GetDeployment(_)
+            result,
+            Err(StartDeploymentError::GetDeployment(
+                GetDeploymentError::ContainerInspect(DockerError::NotFound)
+            ))
         ));
     }
 
@@ -153,7 +385,7 @@ mod tests {
         mock_docker
             .expect_inspect_container()
             .times(1)
-            .returning(move |_, _| Ok(create_test_container_inspect_response()));
+            .returning(move |_, _| Ok(create_healthy_test_container_inspect_response()));
 
         mock_docker
             .expect_start_container()
@@ -163,13 +395,14 @@ mod tests {
         let client = Client::new(mock_docker);
 
         // Act
-        let result = client.start_deployment("test-deployment").await;
+        let result = client
+            .start_deployment("test-deployment", StartDeploymentOptions::default())
+            .await;
 
         // Assert
-        assert!(result.is_err());
         assert!(matches!(
-            result.unwrap_err(),
-            StartDeploymentError::ContainerStart(_)
+            result,
+            Err(StartDeploymentError::ContainerStart(_))
         ));
     }
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -10,6 +10,7 @@ mod logs_options;
 mod mdb_version;
 mod mongodb_type;
 mod port_binding;
+mod start_deployment_options;
 mod state;
 mod watch_options;
 
@@ -25,5 +26,6 @@ pub use logs_options::*;
 pub use mdb_version::*;
 pub use mongodb_type::*;
 pub use port_binding::*;
+pub use start_deployment_options::*;
 pub use state::*;
 pub use watch_options::*;

--- a/src/models/start_deployment_options.rs
+++ b/src/models/start_deployment_options.rs
@@ -1,0 +1,35 @@
+use std::time::Duration;
+
+/// Options for starting an existing local Atlas deployment.
+///
+/// By default `start_deployment` waits for the deployment to become healthy
+/// before returning, matching the behavior of `create_deployment`.
+///
+/// # Examples
+///
+/// ```
+/// use atlas_local::models::StartDeploymentOptions;
+/// use std::time::Duration;
+///
+/// // Wait for the deployment to be healthy, with a custom timeout.
+/// let options = StartDeploymentOptions::builder()
+///     .wait_until_healthy_timeout(Duration::from_secs(120))
+///     .build();
+///
+/// // Return as soon as the container has been started.
+/// let options = StartDeploymentOptions::builder()
+///     .wait_until_healthy(false)
+///     .build();
+/// ```
+#[derive(Clone, Debug, Default, PartialEq, Eq, typed_builder::TypedBuilder)]
+#[builder(doc)]
+pub struct StartDeploymentOptions {
+    /// Whether to wait for the deployment to become healthy before returning.
+    /// Defaults to `true`.
+    #[builder(default, setter(strip_option))]
+    pub wait_until_healthy: Option<bool>,
+
+    /// Maximum duration to wait for the deployment to become healthy.
+    #[builder(default, setter(strip_option))]
+    pub wait_until_healthy_timeout: Option<Duration>,
+}

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -2,7 +2,10 @@
 use atlas_local::{
     Client,
     client::CreateDeploymentStepOutcome,
-    models::{CreateDeploymentOptions, LogsOptions, MongoDBPortBinding, Tail, WatchOptions},
+    models::{
+        CreateDeploymentOptions, LogsOptions, MongoDBPortBinding, StartDeploymentOptions, Tail,
+        WatchOptions,
+    },
 };
 use bollard::{Docker, query_parameters::RemoveContainerOptionsBuilder};
 use tokio::runtime::Handle;
@@ -174,21 +177,11 @@ async fn test_e2e_smoke_test() {
         .await
         .expect("Stopping deployment");
 
+    // start_deployment waits for the deployment to become healthy by default
     client
-        .start_deployment(name)
+        .start_deployment(name, StartDeploymentOptions::default())
         .await
         .expect("Starting deployment");
-
-    // Wait for the deployment to become healthy again
-    client
-        .wait_for_healthy_deployment(
-            name,
-            WatchOptions::builder()
-                .allow_unhealthy_initial_state(true)
-                .build(),
-        )
-        .await
-        .expect("Waiting for deployment to become healthy");
 
     // Pause and unpause the deployment
     client


### PR DESCRIPTION
## Summary

_Jira ticket_: [CLOUDP-424461](https://jira.mongodb.org/browse/CLOUDP-424461)

This PR makes `start_deployment` wait for health by default, matching `create_deployment`.

## Changes

- New `StartDeploymentOptions`  with `wait_until_healthy: Option<bool>` and `wait_until_healthy_timeout: Option<Duration>`, the same field `CreateDeploymentOptions` uses.
- `start_deployment` now takes that options struct and chains `wait_for_healthy_deployment` unless the caller opts out. Added tests and updated the existing ones.
- Updated `tests/e2e_test.rs` to deop the manual `wait_for_healthy_deployment` call that followed `start_deployment`.
- Updated `examples/container_lifecycle.rs` for the new signature.


## Breaking changes

1. `start_deployment(name)` changes to `start_deployment(name, options)`.
2. `StartDeploymentError` gained a variant


Migration:

```rust
// before
client.start_deployment("my-deployment").await?;

// after — waits for health
client.start_deployment("my-deployment", StartDeploymentOptions::default()).await?;

// after — previous behavior
client.start_deployment("my-deployment",
    StartDeploymentOptions::builder().wait_until_healthy(false).build()).await?;
