### PR TITLE
fix(CI): add needed libc6-dev for failing e2e (CLOUDP-429010)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update
-          apt-get install -y curl gcc
+          apt-get install -y curl gcc libc6-dev
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1


### PR DESCRIPTION
## Summary
_Jira ticket_: [CLOUDP-429010](https://jira.mongodb.org/browse/CLOUDP-429010)
Fix the failing e2e-tests GitHub Actions job by installing libc6-dev.

## Cause

This job runs inside an unpinned ubuntu:latest container. The dependency install step (apt-get install -y curl gcc) 
likely started failing after the base image drifted to a newer Ubuntu image. On the newer image, installing gcc no longer brings in libc6-dev by default.

See failing job, which exits with code 101 during the e2e-tests run: [failed job](https://github.com/mongodb/atlas-local-lib/actions/runs/30442097136/job/90543576835).

## Fix

Add libc6-dev to the workflow dependency installation step in `ci.yml`.